### PR TITLE
Fix optional PDF dependency and auth method-code drift

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -28,7 +28,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libpango-1.0-0 libharfbuzz0b libpangoft2-1.0-0 libharfbuzz-subset0
 
       - name: Install dependencies
-        run: uv sync --all-groups
+        run: uv sync --all-groups --extra pdf
 
       - name: Run integration tests
         env:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ uv add ksef2
 
 Requires Python 3.12+.
 
+PDF rendering is optional. Install the `pdf` extra only when you need local
+invoice PDF visualization:
+
+```bash
+pip install "ksef2[pdf]"
+uv add "ksef2[pdf]"
+```
+
 ## Supported OpenAPI Version
 
 The SDK currently supports KSeF OpenAPI version `2.3.0`.
@@ -325,7 +333,7 @@ See [`docs/guides/fa3-builder.md`](docs/guides/fa3-builder.md) for the full buil
 To build an invoice and generate a PDF visualization locally:
 
 ```bash
-uv run -m scripts.examples.invoices.build_fa3_invoice
+uv run --extra pdf -m scripts.examples.invoices.build_fa3_invoice
 ```
 
 This writes both `output/fa3_invoice.xml` and `output/fa3_invoice.pdf`.
@@ -340,8 +348,8 @@ Run examples as modules with `uv run -m ...`; direct execution by file path is n
 - [`scripts/examples/invoices/send_batch.py`](scripts/examples/invoices/send_batch.py) - staged batch upload with explicit session lifecycle
 - [`scripts/examples/invoices/submit_batch.py`](scripts/examples/invoices/submit_batch.py) - one-shot batch submission flow
 - [`scripts/examples/invoices/send_query_export_download.py`](scripts/examples/invoices/send_query_export_download.py) - send, inspect, export, and download invoices
-- [`scripts/examples/invoices/build_fa3_invoice.py`](scripts/examples/invoices/build_fa3_invoice.py) - build an FA(3) invoice, validate the XML, and generate a PDF visualization
-- [`scripts/examples/invoices/build_fa3_invoice_builder.py`](scripts/examples/invoices/build_fa3_invoice_builder.py) - use the nested FA(3) builder DSL and generate XML plus a PDF visualization
+- [`scripts/examples/invoices/build_fa3_invoice.py`](scripts/examples/invoices/build_fa3_invoice.py) - build an FA(3) invoice, validate the XML, and generate a PDF visualization with the `pdf` extra
+- [`scripts/examples/invoices/build_fa3_invoice_builder.py`](scripts/examples/invoices/build_fa3_invoice_builder.py) - use the nested FA(3) builder DSL and generate XML plus a PDF visualization with the `pdf` extra
 - [`scripts/examples/invoices/build_fa3_invoice_sample_1.py`](scripts/examples/invoices/build_fa3_invoice_sample_1.py) - recreate the first official FA(3) sample with the public builder
 - [`scripts/examples/peppol/query_providers.py`](scripts/examples/peppol/query_providers.py) - query public PEPPOL providers
 - [`scripts/examples/scenarios/download_purchase_invoices.py`](scripts/examples/scenarios/download_purchase_invoices.py) - multi-buyer purchase-invoice export scenario

--- a/docs/guides/fa3-builder.md
+++ b/docs/guides/fa3-builder.md
@@ -153,7 +153,7 @@ The SDK ships with a runnable example that:
 Run it from the repository root:
 
 ```bash
-uv run -m scripts.examples.invoices.build_fa3_invoice
+uv run --extra pdf -m scripts.examples.invoices.build_fa3_invoice
 ```
 
 The example writes:
@@ -164,7 +164,7 @@ The example writes:
 If you want the same flow while keeping the builder object around, use:
 
 ```bash
-uv run -m scripts.examples.invoices.build_fa3_invoice_builder
+uv run --extra pdf -m scripts.examples.invoices.build_fa3_invoice_builder
 ```
 
 The PDF is a visualization of the generated XML, which is helpful for previewing invoice content before sending it to KSeF.

--- a/justfile
+++ b/justfile
@@ -1,10 +1,10 @@
 # Run integration tests (requires KSEF credentials in .env)
 integration:
-    source .env.test && uv run pytest tests/integration/ -v -m integration
+    source .env.test && uv run --extra pdf pytest tests/integration/ -v -m integration
 
 # Run end-to-end example tests only (requires KSEF credentials in .env)
 e2e:
-    source .env.test && uv run pytest tests/integration/test_examples.py -v -m integration
+    source .env.test && uv run --extra pdf pytest tests/integration/test_examples.py -v -m integration
 
 
 sync:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,17 @@ dependencies = [
     "dotenv>=0.9.9",
     "requests>=2.32.5",
     "xsdata-pydantic>=24.5",
-    "weasyprint>=63.0",
     "tenacity>=9.0",
     "polyfactory>=3.3.0",
     "beartype>=0.22.9",
     "camel-converter>=5.1.0",
     "pytest-cov>=7.1.0",
     "xsdata>=26.1",
+]
+
+[project.optional-dependencies]
+pdf = [
+    "weasyprint>=63.0",
 ]
 
 [dependency-groups]

--- a/scripts/examples/README.md
+++ b/scripts/examples/README.md
@@ -14,12 +14,12 @@ uv run -m scripts.examples.quickstart
 uv run -m scripts.examples.invoices.send_invoice
 uv run -m scripts.examples.invoices.send_batch
 uv run -m scripts.examples.invoices.submit_batch
-uv run -m scripts.examples.invoices.build_fa3_invoice
-uv run -m scripts.examples.invoices.build_fa3_invoice_builder
+uv run --extra pdf -m scripts.examples.invoices.build_fa3_invoice
+uv run --extra pdf -m scripts.examples.invoices.build_fa3_invoice_builder
 uv run -m scripts.examples.scenarios.download_purchase_invoices
 ```
 
 For FA(3) builder output plus PDF visualization, start with:
 
-- `uv run -m scripts.examples.invoices.build_fa3_invoice`
-- `uv run -m scripts.examples.invoices.build_fa3_invoice_builder`
+- `uv run --extra pdf -m scripts.examples.invoices.build_fa3_invoice`
+- `uv run --extra pdf -m scripts.examples.invoices.build_fa3_invoice_builder`

--- a/src/ksef2/domain/models/auth.py
+++ b/src/ksef2/domain/models/auth.py
@@ -17,6 +17,7 @@ type AuthenticationMethod = Literal[
     "personal_signature",
     "peppol_signature",
     "ksef_certificate",
+    "other",
 ]
 
 type AuthenticationMethodCategory = Literal[
@@ -43,6 +44,7 @@ class AuthenticationMethodEnum(StrEnum):
     PERSONAL_SIGNATURE = "personal_signature"
     PEPPOL_SIGNATURE = "peppol_signature"
     KSEF_CERTIFICATE = "ksef_certificate"
+    OTHER = "other"
 
 
 class AuthenticationMethodCategoryEnum(StrEnum):

--- a/src/ksef2/infra/mappers/auth/responses.py
+++ b/src/ksef2/infra/mappers/auth/responses.py
@@ -92,26 +92,20 @@ def _from_spec(response: BaseModel | Enum) -> object:
     )
 
 
+_AUTHENTICATION_METHOD_BY_CODE: dict[str, AuthenticationMethod] = {
+    "token.ksef": "token",
+    "national-node.trusted-profile": "trusted_profile",
+    "other.internal-certificate": "internal_certificate",
+    "xades.qualified-signature": "qualified_signature",
+    "xades.qualified-seal": "qualified_seal",
+    "xades.personal-signature": "personal_signature",
+    "xades.peppol-signature": "peppol_signature",
+    "xades.ksef-certificate": "ksef_certificate",
+}
+
+
 def _method_from_code(code: str) -> AuthenticationMethod:
-    match code:
-        case "token.ksef":
-            return "token"
-        case "national-node.trusted-profile":
-            return "trusted_profile"
-        case "other.internal-certificate":
-            return "internal_certificate"
-        case "xades.qualified-signature":
-            return "qualified_signature"
-        case "xades.qualified-seal":
-            return "qualified_seal"
-        case "xades.personal-signature":
-            return "personal_signature"
-        case "xades.peppol-signature":
-            return "peppol_signature"
-        case "xades.ksef-certificate":
-            return "ksef_certificate"
-        case _:
-            raise ValueError(f"Unsupported authentication method code: {code!r}")
+    return _AUTHENTICATION_METHOD_BY_CODE.get(code, "other")
 
 
 @_from_spec.register

--- a/src/ksef2/services/renderers/pdf.py
+++ b/src/ksef2/services/renderers/pdf.py
@@ -1,11 +1,24 @@
 """PDF exporter for FA3 invoices using XSLT transformation and WeasyPrint."""
 
+from importlib import import_module
 from pathlib import Path
-from typing import final
+from typing import Any, final
 
 from ksef2.services.renderers.xslt import InvoiceXSLTRenderer
 from ksef2.infra.schema.fa3 import DEFAULT_CSS_OVERRIDES
-from weasyprint import CSS, HTML
+
+
+def _load_weasyprint() -> Any:
+    try:
+        return import_module("weasyprint")
+    except ModuleNotFoundError as exc:
+        if exc.name == "weasyprint":
+            raise ImportError(
+                "InvoicePDFExporter requires the optional PDF dependencies. "
+                "Install them with `pip install 'ksef2[pdf]'` or "
+                "`uv add 'ksef2[pdf]'`."
+            ) from exc
+        raise
 
 
 @final
@@ -16,6 +29,7 @@ class InvoicePDFExporter:
         enable_code_lookups: bool = False,
         html_overrides: str | None = None,
     ):
+        self._weasyprint = _load_weasyprint()
         self._xslt_renderer = InvoiceXSLTRenderer(
             stylesheet_path=stylesheet_path,
             enable_code_lookups=enable_code_lookups,
@@ -30,9 +44,9 @@ class InvoicePDFExporter:
         return self._xslt_renderer.stylesheet_path
 
     def _render_html(self, html_content: str) -> bytes:
-        stylesheets = [CSS(string=self._html_overrides)]
+        stylesheets = [self._weasyprint.CSS(string=self._html_overrides)]
 
-        pdf_bytes = HTML(
+        pdf_bytes = self._weasyprint.HTML(
             string=html_content, base_url=str(self.stylesheet_path.parent)
         ).write_pdf(stylesheets=stylesheets)
 

--- a/tests/unit/mappers/test_auth.py
+++ b/tests/unit/mappers/test_auth.py
@@ -138,6 +138,25 @@ class TestAuthResponseMapper:
         assert output.authentication_method_category == "xades_signature"
         assert output.authentication_method_code == "xades.ksef-certificate"
 
+    def test_map_authentication_session_unknown_method_code(self) -> None:
+        mapped_input = AuthenticationListItemFactory.build(
+            authenticationMethod=spec.AuthenticationMethod.InternalCertificate,
+            authenticationMethodInfo=spec.AuthenticationMethodInfo(
+                category=spec.AuthenticationMethodCategory.Other,
+                code="future.authentication-method",
+                displayName="Future authentication method",
+            ),
+        )
+
+        output = from_spec(mapped_input)
+
+        assert output.authentication_method == "other"
+        assert output.authentication_method_category == "other"
+        assert output.authentication_method_code == "future.authentication-method"
+        assert (
+            output.authentication_method_display_name == "Future authentication method"
+        )
+
     def test_map_authentication_sessions_response(
         self, auth_list_resp: BaseFactory[spec.AuthenticationListResponse]
     ) -> None:

--- a/tests/unit/services/test_pdf_renderer.py
+++ b/tests/unit/services/test_pdf_renderer.py
@@ -1,0 +1,35 @@
+import tomllib
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ksef2.services.renderers import InvoicePDFExporter, InvoiceXSLTRenderer
+
+
+def test_renderers_package_imports_without_loading_weasyprint() -> None:
+    import ksef2.services.renderers as renderers
+
+    assert renderers.InvoiceXSLTRenderer is InvoiceXSLTRenderer
+    assert renderers.InvoicePDFExporter is InvoicePDFExporter
+
+
+def test_pdf_exporter_reports_missing_optional_dependency() -> None:
+    missing_weasyprint = ModuleNotFoundError(
+        "No module named 'weasyprint'", name="weasyprint"
+    )
+
+    with patch(
+        "ksef2.services.renderers.pdf.import_module",
+        side_effect=missing_weasyprint,
+    ):
+        with pytest.raises(ImportError, match=r"ksef2\[pdf\]"):
+            _ = InvoicePDFExporter()
+
+
+def test_weasyprint_is_declared_as_pdf_extra() -> None:
+    pyproject_path = Path(__file__).parents[3] / "pyproject.toml"
+    pyproject = tomllib.loads(pyproject_path.read_text())
+
+    assert "weasyprint>=63.0" not in pyproject["project"]["dependencies"]
+    assert pyproject["project"]["optional-dependencies"]["pdf"] == ["weasyprint>=63.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -779,9 +779,13 @@ dependencies = [
     { name = "signxml" },
     { name = "structlog" },
     { name = "tenacity" },
-    { name = "weasyprint" },
     { name = "xsdata" },
     { name = "xsdata-pydantic" },
+]
+
+[package.optional-dependencies]
+pdf = [
+    { name = "weasyprint" },
 ]
 
 [package.dev-dependencies]
@@ -815,10 +819,11 @@ requires-dist = [
     { name = "signxml", specifier = ">=4.0" },
     { name = "structlog", specifier = ">=25.5.0" },
     { name = "tenacity", specifier = ">=9.0" },
-    { name = "weasyprint", specifier = ">=63.0" },
+    { name = "weasyprint", marker = "extra == 'pdf'", specifier = ">=63.0" },
     { name = "xsdata", specifier = ">=26.1" },
     { name = "xsdata-pydantic", specifier = ">=24.5" },
 ]
+provides-extras = ["pdf"]
 
 [package.metadata.requires-dev]
 codegen = [


### PR DESCRIPTION
## What changed

- Moved WeasyPrint out of core dependencies and into the `pdf` extra.
- Kept PDF renderer imports lightweight, with a clear error when the extra is missing.
- Updated README/example/runbook/CI commands that exercise PDF generation to request the `pdf` extra.
- Changed auth method code mapping so unknown backend `authenticationMethodInfo.code` values classify as `other` while preserving the raw code and display name.

## Validation

- `PYTHONPATH=/Users/user/PycharmProjects/ksef/KSEF_SDK_fix_open_issues/src /tmp/ksef-fix-venv/bin/python -m pytest tests/unit/mappers/test_auth.py tests/unit/services/test_pdf_renderer.py -q`
- `PYTHONPATH=/Users/user/PycharmProjects/ksef/KSEF_SDK_fix_open_issues/src /tmp/ksef-fix-venv/bin/python -m pytest tests/unit/ -q`
- `/tmp/ksef-fix-venv/bin/python -m ruff format --check src/ tests/`
- `/tmp/ksef-fix-venv/bin/python -m ruff check src/ tests/`
- `/tmp/ksef-fix-venv/bin/basedpyright --level error`
- `/tmp/ksef-fix-venv/bin/python -m build --wheel --no-isolation`
- Verified wheel metadata exposes `weasyprint` only under `extra == 'pdf'`.

Fixes #11
Fixes #25
