### PR TITLE
Support gross unit price FA(3) lines

### DIFF
--- a/src/ksef2/domain/models/fa3/body/row.py
+++ b/src/ksef2/domain/models/fa3/body/row.py
@@ -194,6 +194,18 @@ class InvoiceRow(KSeFBaseModel):
     def compute_financial_field(self) -> Self:
         rate = self._vat_percent()
 
+        if (
+            self.gross_amount is None
+            and self.net_amount is None
+            and self.unit_price_net is None
+            and self.unit_price_gross is not None
+            and self.quantity is not None
+        ):
+            base_gross = self.unit_price_gross * self.quantity
+            self.gross_amount = round_pln(base_gross) - (
+                self.discount_amount or Decimal("0.00")
+            )
+
         if self.gross_amount is not None:
             if self.net_amount is None:
                 if rate is None:

--- a/src/ksef2/services/builders/fa3/sub/rows.py
+++ b/src/ksef2/services/builders/fa3/sub/rows.py
@@ -43,10 +43,18 @@ RowQuantityParam = Annotated[
     ),
 ]
 RowUnitPriceNetParam = Annotated[
-    Decimal,
+    Decimal | None,
     builder_param(
-        "Net unit price for one item or one service unit.",
+        "Net unit price for one item or one service unit. Provide either this or unit_price_gross.",
         examples=["100.00", "2499.99"],
+        format="decimal-string",
+    ),
+]
+RowUnitPriceGrossParam = Annotated[
+    Decimal | None,
+    builder_param(
+        "Gross unit price for one item or one service unit. Provide either this or unit_price_net.",
+        examples=["123.00", "3074.99"],
         format="decimal-string",
     ),
 ]
@@ -223,6 +231,16 @@ def _coerce_vat_classification(
     return coerce_vat_classification(vat_classification)
 
 
+def _validate_unit_price_choice(
+    unit_price_net: Decimal | None,
+    unit_price_gross: Decimal | None,
+) -> None:
+    if unit_price_net is not None and unit_price_gross is not None:
+        raise ValueError("Provide either unit_price_net or unit_price_gross, not both.")
+    if unit_price_net is None and unit_price_gross is None:
+        raise ValueError("Provide unit_price_net or unit_price_gross.")
+
+
 class RowsBuilder[TParent]:
     def __init__(
         self,
@@ -245,7 +263,7 @@ class RowsBuilder[TParent]:
         *,
         name: RowNameParam,
         quantity: RowQuantityParam,
-        unit_price_net: RowUnitPriceNetParam,
+        unit_price_net: RowUnitPriceNetParam = None,
         vat_rate: RowVatRateParam = None,
         vat_classification: RowVatClassificationParam = None,
         unit_of_measure: RowUnitOfMeasureParam = "szt",
@@ -256,7 +274,7 @@ class RowsBuilder[TParent]:
         net_amount: RowOverrideAmountParam = None,
         vat_amount: RowOverrideAmountParam = None,
         gross_amount: RowOverrideAmountParam = None,
-        unit_price_gross: RowOverrideAmountParam = None,
+        unit_price_gross: RowUnitPriceGrossParam = None,
         vat_rate_xii: RowVatRateXiiParam = None,
         annex_15_marker: RowAnnex15Param = None,
         excise_amount: RowExciseAmountParam = None,
@@ -271,6 +289,7 @@ class RowsBuilder[TParent]:
         currency_exchange_rate: RowCurrencyExchangeRateParam = None,
         before_correction: RowBeforeCorrectionParam = False,
     ) -> Self:
+        _validate_unit_price_choice(unit_price_net, unit_price_gross)
         self._state["rows"].append(
             InvoiceRow(
                 name=name,
@@ -309,7 +328,7 @@ class RowsBuilder[TParent]:
         *,
         name: RowNameParam,
         quantity: RowQuantityParam,
-        unit_price_net: RowUnitPriceNetParam,
+        unit_price_net: RowUnitPriceNetParam = None,
         vat_rate: RowVatRateParam = None,
         vat_classification: RowVatClassificationParam = None,
         unit_of_measure: RowUnitOfMeasureParam = "szt",
@@ -320,7 +339,7 @@ class RowsBuilder[TParent]:
         net_amount: RowOverrideAmountParam = None,
         vat_amount: RowOverrideAmountParam = None,
         gross_amount: RowOverrideAmountParam = None,
-        unit_price_gross: RowOverrideAmountParam = None,
+        unit_price_gross: RowUnitPriceGrossParam = None,
         vat_rate_xii: RowVatRateXiiParam = None,
         annex_15_marker: RowAnnex15Param = None,
         excise_amount: RowExciseAmountParam = None,

--- a/tests/unit/mappers/test_fa3_lines.py
+++ b/tests/unit/mappers/test_fa3_lines.py
@@ -104,6 +104,25 @@ def test_lines_to_spec_maps_optional_fields_to_none() -> None:
     assert output.stan_przed is None
 
 
+def test_lines_to_spec_maps_gross_priced_invoice_line() -> None:
+    output = lines_to_spec(
+        InvoiceRow(
+            name="Gross-priced service",
+            quantity=Decimal("2"),
+            unit_price_gross=Decimal("123.00"),
+            vat_rate=VatRate.VAT_23,
+        ),
+        row_number=2,
+    )
+
+    assert output.p_9_a is None
+    assert output.p_9_b == "123.00"
+    assert output.p_11 == "200.00"
+    assert output.p_11_a == "246.00"
+    assert output.p_11_vat == "46.00"
+    assert output.p_12 == TstawkaPodatku.VALUE_23
+
+
 def test_lines_to_spec_maps_zero_wdt_bucket_to_brochure_specific_value() -> None:
     output = lines_to_spec(
         InvoiceRow(

--- a/tests/unit/test_fa3_invoice_models.py
+++ b/tests/unit/test_fa3_invoice_models.py
@@ -232,6 +232,20 @@ def test_invoice_line_derives_structured_vat_classification_from_legacy_inputs()
     assert line.tax_regime is TaxRegime.STANDARD
 
 
+def test_invoice_line_computes_amounts_from_gross_unit_price() -> None:
+    line = InvoiceRow(
+        name="Gross-priced service",
+        quantity=Decimal("2"),
+        unit_price_gross=Decimal("123.00"),
+        vat_rate=VatRate.VAT_23,
+    )
+
+    assert line.unit_price_net is None
+    assert line.gross_amount == Decimal("246.00")
+    assert line.net_amount == Decimal("200.00")
+    assert line.vat_amount == Decimal("46.00")
+
+
 def test_invoice_line_derives_legacy_fields_from_structured_vat_classification() -> (
     None
 ):

--- a/tests/unit/test_fa3_public_api.py
+++ b/tests/unit/test_fa3_public_api.py
@@ -1,6 +1,8 @@
 from datetime import date
 from decimal import Decimal
 
+import pytest
+
 from ksef2.fa3 import FA3InvoiceBuilder, KsefInvoice, VatRate
 
 
@@ -38,6 +40,69 @@ def test_fa3_public_builder_builds_invoice() -> None:
     assert isinstance(invoice, KsefInvoice)
     assert invoice.body.invoice_number == "FV/2026/03/0001"
     assert invoice.body.rows[0].vat_rate is VatRate.VAT_23
+
+
+def test_fa3_public_builder_builds_gross_priced_line() -> None:
+    invoice = (
+        FA3InvoiceBuilder()
+        .header(system_info="public api gross test")
+        .seller(
+            name="ACME S.A.",
+            tax_id="1234567890",
+            country_code="PL",
+            address_line_1="ul. Przykladowa 123",
+        )
+        .buyer(
+            name="XYZ GmbH",
+            country_code="DE",
+            address_line_1="Unter den Linden 1",
+        )
+        .standard()
+        .issue_date(date(2026, 3, 29))
+        .invoice_number("FV/2026/03/0002")
+        .rows()
+        .add_line(
+            name="Gross-priced service",
+            quantity=Decimal("2"),
+            unit_of_measure="h",
+            unit_price_gross=Decimal("123.00"),
+            vat_rate=VatRate.VAT_23,
+        )
+        .done()
+        .done()
+        .build()
+    )
+
+    row = invoice.body.rows[0]
+    assert row.unit_price_net is None
+    assert row.unit_price_gross == Decimal("123.00")
+    assert row.gross_amount == Decimal("246.00")
+    assert row.net_amount == Decimal("200.00")
+    assert row.vat_amount == Decimal("46.00")
+
+
+def test_fa3_public_builder_rejects_ambiguous_unit_price_inputs() -> None:
+    rows = FA3InvoiceBuilder().standard().rows()
+
+    with pytest.raises(ValueError, match="unit_price_net or unit_price_gross"):
+        rows.add_line(
+            name="Ambiguous service",
+            quantity=Decimal("1"),
+            unit_price_net=Decimal("100.00"),
+            unit_price_gross=Decimal("123.00"),
+            vat_rate=VatRate.VAT_23,
+        )
+
+
+def test_fa3_public_builder_requires_one_unit_price_input() -> None:
+    rows = FA3InvoiceBuilder().standard().rows()
+
+    with pytest.raises(ValueError, match="unit_price_net or unit_price_gross"):
+        rows.add_line(
+            name="Unpriced service",
+            quantity=Decimal("1"),
+            vat_rate=VatRate.VAT_23,
+        )
 
 
 def test_services_builders_exports_only_canonical_builder() -> None:


### PR DESCRIPTION
## Summary

Adds first-class gross unit price support to FA(3) invoice rows so callers can use `unit_price_gross` directly in `rows().add_line(...)`.

## Changes

- Computes line `gross_amount`, `net_amount`, and `vat_amount` from `unit_price_gross * quantity` when net pricing is not supplied.
- Makes `unit_price_net` optional in the row builder and adds `unit_price_gross` as the alternate pricing input.
- Rejects ambiguous builder calls that provide both `unit_price_net` and `unit_price_gross`, and rejects calculated builder rows with neither unit price.
- Adds model, builder, and mapper tests covering gross-priced lines.

## Validation

- `uv run ruff check src/ksef2/services/builders/fa3/sub/rows.py src/ksef2/domain/models/fa3/body/row.py tests/unit/test_fa3_public_api.py tests/unit/test_fa3_invoice_models.py tests/unit/mappers/test_fa3_lines.py`
- `uv run pytest tests/unit`

Related to #47.