### PR TITLE
Investigate InvoiceRow VAT classification guards

### DIFF
--- a/tests/unit/test_fa3_invoice_models.py
+++ b/tests/unit/test_fa3_invoice_models.py
@@ -264,6 +264,74 @@ def test_invoice_line_derives_legacy_fields_from_structured_vat_classification()
     assert line.vat_rate is VatRate.VAT_23
 
 
+@pytest.mark.parametrize(
+    ("vat_classification", "sale_category", "vat_rate"),
+    [
+        (None, None, VatRate.VAT_23),
+        (None, SaleCategory.RATE_23, None),
+        (
+            VatClassification(
+                treatment=VatTreatment.TAXABLE,
+                rate=Decimal("23"),
+            ),
+            None,
+            None,
+        ),
+        (
+            VatClassification(
+                treatment=VatTreatment.TAXABLE,
+                rate=Decimal("23"),
+            ),
+            SaleCategory.RATE_23,
+            None,
+        ),
+        (
+            VatClassification(
+                treatment=VatTreatment.TAXABLE,
+                rate=Decimal("23"),
+            ),
+            None,
+            VatRate.VAT_23,
+        ),
+        (None, SaleCategory.RATE_23, VatRate.VAT_23),
+    ],
+)
+def test_invoice_line_normalizes_partial_vat_classification_fields(
+    vat_classification: VatClassification | None,
+    sale_category: SaleCategory | None,
+    vat_rate: VatRate | None,
+) -> None:
+    # Documents issue #53: through InvoiceRow(...) standard VAT inputs cannot
+    # reach validation with exactly one classification field missing.
+    line = InvoiceRow(
+        name="Consulting service",
+        quantity=Decimal("1"),
+        unit_price_net=Decimal("100.00"),
+        net_amount=Decimal("100.00"),
+        vat_classification=vat_classification,
+        sale_category=sale_category,
+        vat_rate=vat_rate,
+    )
+
+    assert line.vat_classification is not None
+    assert line.sale_category == line.vat_classification.sale_category
+    assert line.vat_rate == line.vat_classification.vat_rate
+
+
+def test_invoice_line_rejects_amounted_standard_line_without_vat_classification() -> (
+    None
+):
+    # Keep this message-agnostic: the exact validation text is not a documented
+    # public API, so message-only mutants should be treated as low signal.
+    with pytest.raises(ValidationError):
+        InvoiceRow(
+            name="Consulting service",
+            quantity=Decimal("1"),
+            unit_price_net=Decimal("100.00"),
+            net_amount=Decimal("100.00"),
+        )
+
+
 def test_invoice_entity_accepts_contact_and_customer_number() -> None:
     entity = InvoiceEntity(
         tax_id="1234567890",


### PR DESCRIPTION
## Summary
- Documented that standard InvoiceRow(...) VAT inputs with partial vat_classification, sale_category, and vat_rate fields are normalized before validation.
- Added a message-agnostic rejection test for amounted standard rows with no VAT classification fields.
- Classified message-only mutations as low signal unless validation text becomes a documented public API.

Fixes #53

## Checks
- uv run pytest tests/unit/test_fa3_invoice_models.py
- uv run pytest tests/unit/
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run basedpyright --level error