### PR TITLE
Port export-part sanitization to sync fetch_package

### DIFF
--- a/src/ksef2/services/async_invoices.py
+++ b/src/ksef2/services/async_invoices.py
@@ -20,6 +20,7 @@ from ksef2.domain.models.invoices import (
 )
 from ksef2.domain.models.pagination import InvoiceMetadataParams
 from ksef2.logging import get_logger
+from ksef2.services.export_parts import safe_part_filename
 
 logger = get_logger(__name__)
 
@@ -164,16 +165,7 @@ class AsyncInvoicesService:
                 iv=export.iv,
             )
 
-            sanitized_part_name = Path(part.part_name.replace("\\", "/")).name
-            output_filename = sanitized_part_name.removesuffix(".aes")
-            if (
-                "\x00" in output_filename
-                or output_filename.startswith(".")
-                or output_filename in {"", ".", ".."}
-            ):
-                raise ValueError(
-                    f"Invalid export package part name: {part.part_name!r}"
-                )
+            output_filename = safe_part_filename(part.part_name)
             output_file = target_path / output_filename
             await asyncio.to_thread(output_file.write_bytes, zip_data)
 

--- a/src/ksef2/services/export_parts.py
+++ b/src/ksef2/services/export_parts.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+def safe_part_filename(part_name: str) -> str:
+    """Return a sanitized local filename for an export package part.
+
+    Raises ValueError for path-traversal attempts and degenerate names.
+    """
+    sanitized_part_name = Path(part_name.replace("\\", "/")).name
+    output_filename = sanitized_part_name.removesuffix(".aes")
+    if (
+        "\x00" in output_filename
+        or output_filename.startswith(".")
+        or output_filename in {"", ".", ".."}
+    ):
+        raise ValueError(f"Invalid export package part name: {part_name!r}")
+    return output_filename

--- a/src/ksef2/services/invoices.py
+++ b/src/ksef2/services/invoices.py
@@ -9,7 +9,6 @@ from ksef2.core.middlewares.auth import BearerTokenMiddleware
 from ksef2.core.polling import poll_until
 from ksef2.core.protocols import Middleware
 from ksef2.core.stores import CertificateStore
-from ksef2.logging import get_logger
 from ksef2.domain.models.compression import CompressionType
 from ksef2.domain.models.invoices import (
     ExportHandle,
@@ -20,6 +19,8 @@ from ksef2.domain.models.invoices import (
     QueryInvoicesMetadataResponse,
 )
 from ksef2.domain.models.pagination import InvoiceMetadataParams
+from ksef2.logging import get_logger
+from ksef2.services.export_parts import safe_part_filename
 
 logger = get_logger(__name__)
 
@@ -162,7 +163,7 @@ class InvoicesService:
 
             zip_data = decrypt_aes_cbc(resp.content, key=export.aes_key, iv=export.iv)
 
-            output_filename = part.part_name.replace(".aes", "")
+            output_filename = safe_part_filename(part.part_name)
             output_file = target_path / output_filename
 
             with open(output_file, "wb") as f:

--- a/tests/unit/services/test_export_parts.py
+++ b/tests/unit/services/test_export_parts.py
@@ -1,0 +1,28 @@
+import pytest
+
+from ksef2.services.export_parts import safe_part_filename
+
+
+@pytest.mark.parametrize(
+    ("part_name", "expected"),
+    [
+        ("part-1.zip.aes", "part-1.zip"),
+        ("../unsafe/subdir/part-1.zip.aes", "part-1.zip"),
+        ("..\\unsafe\\subdir\\part-2.zip.aes", "part-2.zip"),
+        ("report.aes.backup.zip.aes", "report.aes.backup.zip"),
+    ],
+)
+def test_safe_part_filename_returns_sanitized_filename(
+    part_name: str,
+    expected: str,
+) -> None:
+    assert safe_part_filename(part_name) == expected
+
+
+@pytest.mark.parametrize(
+    "part_name",
+    ["", ".", "..", ".aes", ".hidden.zip.aes", "bad\x00.zip.aes"],
+)
+def test_safe_part_filename_rejects_invalid_names(part_name: str) -> None:
+    with pytest.raises(ValueError, match="Invalid export package part name"):
+        _ = safe_part_filename(part_name)

--- a/tests/unit/services/test_invoices.py
+++ b/tests/unit/services/test_invoices.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timezone
+from pathlib import Path
 from unittest.mock import patch
 
+import httpx
 import pytest
 from polyfactory import BaseFactory
 
@@ -41,6 +43,29 @@ def _ready_export_package() -> spec.InvoicePackage:
                 }
             ],
             "isTruncated": False,
+        }
+    )
+
+
+def _invoice_package_with_part_name(part_name: str) -> invoices.InvoicePackage:
+    return invoices.InvoicePackage.model_validate(
+        {
+            "invoice_count": 1,
+            "size": 128,
+            "parts": [
+                {
+                    "ordinal_number": 1,
+                    "part_name": part_name,
+                    "method": "GET",
+                    "url": "https://example.com/export/part-1",
+                    "part_size": 64,
+                    "part_hash": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+                    "encrypted_part_size": 128,
+                    "encrypted_part_hash": "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=",
+                    "expiration_date": datetime.now(timezone.utc),
+                }
+            ],
+            "is_truncated": False,
         }
     )
 
@@ -112,6 +137,81 @@ class TestInvoicesService:
                 )
 
         assert exc_info.value.exception_code == ExceptionCode.VALIDATION_ERROR
+
+    @pytest.mark.parametrize(
+        ("part_name", "expected_name"),
+        [
+            ("../unsafe/subdir/part-1.zip.aes", "part-1.zip"),
+            ("..\\unsafe\\subdir\\part-2.zip.aes", "part-2.zip"),
+            ("../unsafe\\subdir/part-3.zip.aes", "part-3.zip"),
+        ],
+    )
+    def test_fetch_package_sanitizes_part_name_and_removes_aes_suffix(
+        self,
+        part_name: str,
+        expected_name: str,
+        fake_transport: FakeTransport,
+        tmp_path: Path,
+    ) -> None:
+        service = _build_service(fake_transport)
+        package = _invoice_package_with_part_name(part_name)
+        handle = invoices.ExportHandle(
+            reference_number="ref",
+            aes_key=b"0" * 32,
+            iv=b"1" * 16,
+        )
+        fake_transport.responses.append(
+            httpx.Response(
+                status_code=200,
+                content=b"encrypted",
+                request=httpx.Request("GET", "https://example.com/export/part-1"),
+            )
+        )
+
+        with patch(
+            "ksef2.services.invoices.decrypt_aes_cbc", return_value=b"decrypted"
+        ):
+            saved_files = service.fetch_package(
+                package=package,
+                export=handle,
+                target_directory=tmp_path,
+            )
+
+        assert saved_files == [tmp_path / expected_name]
+        assert saved_files[0].read_bytes() == b"decrypted"
+        assert not (tmp_path.parent / expected_name).exists()
+
+    @pytest.mark.parametrize(
+        "part_name", [".", "..", ".aes", ".hidden.zip.aes", "bad\x00.zip.aes"]
+    )
+    def test_fetch_package_rejects_invalid_part_names(
+        self,
+        part_name: str,
+        fake_transport: FakeTransport,
+        tmp_path: Path,
+    ) -> None:
+        service = _build_service(fake_transport)
+        package = _invoice_package_with_part_name(part_name)
+        handle = invoices.ExportHandle(
+            reference_number="ref",
+            aes_key=b"0" * 32,
+            iv=b"1" * 16,
+        )
+        fake_transport.responses.append(
+            httpx.Response(
+                status_code=200,
+                content=b"encrypted",
+                request=httpx.Request("GET", "https://example.com/export/part-1"),
+            )
+        )
+
+        with patch("ksef2.services.invoices.decrypt_aes_cbc", return_value=b"x"):
+            with pytest.raises(ValueError, match="Invalid export package part name"):
+                _ = service.fetch_package(
+                    package=package,
+                    export=handle,
+                    target_directory=tmp_path,
+                )
 
     def test_wait_for_invoices_returns_when_metadata_appears(
         self,


### PR DESCRIPTION
## Summary

- Extracted export package part filename sanitization into a shared `safe_part_filename` helper.
- Updated both sync and async invoice package fetch paths to use the shared helper.
- Added direct sanitizer tests and mirrored sync fetch-package sanitization/rejection coverage.

## Issue

Refs #65

## Verification

- `just sync`
- `just lint && just format-check && just typecheck && just test`