### PR TITLE
Fix layering inversions and remove dead code

### DIFF
--- a/src/ksef2/domain/models/pagination.py
+++ b/src/ksef2/domain/models/pagination.py
@@ -18,10 +18,12 @@ from ksef2.domain.models.session import (
     session_type_to_spec,
 )
 from ksef2.domain.models.tokens import TokenAuthorIdentifierType, TokenStatus
-from ksef2.endpoints.base import OffsetPaginationQueryParams
-from ksef2.endpoints.invoices import InvoiceMetadataQueryParams
-from ksef2.endpoints.session import ListSessionsQueryParams
-from ksef2.endpoints.tokens import ListTokensQueryParams
+from ksef2.domain.types import (
+    InvoiceMetadataQueryParams,
+    ListSessionsQueryParams,
+    ListTokensQueryParams,
+    OffsetPaginationQueryParams,
+)
 
 
 class PageSizeMixin(BaseModel):

--- a/src/ksef2/domain/models/pagination.py
+++ b/src/ksef2/domain/models/pagination.py
@@ -113,21 +113,6 @@ class SessionFiltersMixin(BaseModel):
         return [session_status_to_spec(status) for status in value]
 
 
-class SessionListParams(SessionFiltersMixin, TokenPaginationParams):
-    """GET /sessions"""
-
-    page_size: int = Field(default=10, ge=10, le=1000)
-    session_type: SessionType
-    reference_number: str | None = None
-    date_created_from: datetime | None = None
-    date_created_to: datetime | None = None
-    date_closed_from: datetime | None = None
-    date_closed_to: datetime | None = None
-    date_modified_from: datetime | None = None
-    date_modified_to: datetime | None = None
-    statuses: list[SessionStatus] | None = None
-
-
 class SessionInvoiceListParams(TokenPaginationParams):
     page_size: int = Field(default=10, ge=10, le=1000)
 
@@ -137,9 +122,6 @@ class TokenListParams(KSeFBaseParams[ListTokensQueryParams], PageSizeMixin):
     description: str | None = None
     author_identifier: str | None = None
     author_identifier_type: TokenAuthorIdentifierType | None = None
-
-
-class AuthSessionListParams(TokenPaginationParams): ...
 
 
 class ListSessionsQuery(

--- a/src/ksef2/domain/types.py
+++ b/src/ksef2/domain/types.py
@@ -1,4 +1,50 @@
-from typing import Literal
+from typing import Literal, NotRequired, TypedDict
+
+OffsetPaginationQueryParams = TypedDict(
+    "OffsetPaginationQueryParams",
+    {
+        "pageOffset": NotRequired[int | None],
+        "pageSize": NotRequired[int | None],
+    },
+)
+
+InvoiceMetadataQueryParams = TypedDict(
+    "InvoiceMetadataQueryParams",
+    {
+        "sortOrder": NotRequired[str | None],
+        "pageOffset": NotRequired[int | None],
+        "pageSize": NotRequired[int | None],
+    },
+)
+
+ListSessionsQueryParams = TypedDict(
+    "ListSessionsQueryParams",
+    {
+        "pageSize": NotRequired[int | None],
+        "sessionType": Literal["Online", "Batch"],
+        "referenceNumber": NotRequired[str | None],
+        "dateCreatedFrom": NotRequired[str | None],
+        "dateCreatedTo": NotRequired[str | None],
+        "dateClosedFrom": NotRequired[str | None],
+        "dateClosedTo": NotRequired[str | None],
+        "dateModifiedFrom": NotRequired[str | None],
+        "dateModifiedTo": NotRequired[str | None],
+        "statuses": NotRequired[
+            list[Literal["InProgress", "Succeeded", "Failed", "Cancelled"]] | None
+        ],
+    },
+)
+
+ListTokensQueryParams = TypedDict(
+    "ListTokensQueryParams",
+    {
+        "status": NotRequired[list[str] | None],
+        "description": NotRequired[str | None],
+        "authorIdentifier": NotRequired[str | None],
+        "authorIdentifierType": NotRequired[str | None],
+        "pageSize": NotRequired[int | None],
+    },
+)
 
 type CurrencyCodes = Literal[
     "AED",

--- a/src/ksef2/endpoints/async_certificates.py
+++ b/src/ksef2/endpoints/async_certificates.py
@@ -1,8 +1,8 @@
 from typing import Unpack, final
 
 from ksef2.core import routes
+from ksef2.domain.types import OffsetPaginationQueryParams
 from ksef2.endpoints.async_base import AsyncBaseEndpoints
-from ksef2.endpoints.base import OffsetPaginationQueryParams
 from ksef2.infra.schema.api import spec
 
 

--- a/src/ksef2/endpoints/async_invoices.py
+++ b/src/ksef2/endpoints/async_invoices.py
@@ -1,8 +1,9 @@
-from typing import NotRequired, TypedDict, Unpack, final
+from typing import TypedDict, Unpack, final
 
 from pydantic import TypeAdapter
 
 from ksef2.core import routes
+from ksef2.domain.types import InvoiceMetadataQueryParams
 from ksef2.endpoints.async_base import AsyncBaseEndpoints
 from ksef2.infra.schema.api import spec
 from ksef2.infra.schema.api.supp.invoices import (
@@ -10,14 +11,6 @@ from ksef2.infra.schema.api.supp.invoices import (
     SendInvoiceRequest,
 )
 
-InvoiceMetadataQueryParams = TypedDict(
-    "InvoiceMetadataQueryParams",
-    {
-        "sortOrder": NotRequired[str | None],
-        "pageOffset": NotRequired[int | None],
-        "pageSize": NotRequired[int | None],
-    },
-)
 SessionInvoiceListQueryParams = TypedDict(
     "SessionInvoiceListQueryParams",
     {

--- a/src/ksef2/endpoints/async_peppol.py
+++ b/src/ksef2/endpoints/async_peppol.py
@@ -3,8 +3,8 @@
 from typing import Unpack, final
 
 from ksef2.core import routes
+from ksef2.domain.types import OffsetPaginationQueryParams
 from ksef2.endpoints.async_base import AsyncBaseEndpoints
-from ksef2.endpoints.base import OffsetPaginationQueryParams
 from ksef2.infra.schema.api import spec
 
 

--- a/src/ksef2/endpoints/async_permissions.py
+++ b/src/ksef2/endpoints/async_permissions.py
@@ -1,8 +1,8 @@
 from typing import Unpack, final
 
 from ksef2.core import routes
+from ksef2.domain.types import OffsetPaginationQueryParams
 from ksef2.endpoints.async_base import AsyncBaseEndpoints
-from ksef2.endpoints.base import OffsetPaginationQueryParams
 from ksef2.infra.schema.api import spec
 
 

--- a/src/ksef2/endpoints/async_session.py
+++ b/src/ksef2/endpoints/async_session.py
@@ -1,32 +1,16 @@
 """Async session management endpoints."""
 
-from typing import Literal, NotRequired, TypedDict, Unpack, final
+from typing import Unpack, final
 
 from pydantic import TypeAdapter
 
 from ksef2.core import routes
+from ksef2.domain.types import ListSessionsQueryParams
 from ksef2.endpoints.async_base import AsyncBaseEndpoints
 from ksef2.infra.schema.api import spec
 from ksef2.infra.schema.api.supp.batch import OpenBatchSessionRequest
 from ksef2.infra.schema.api.supp.session import OpenOnlineSessionRequest
 
-ListSessionsQueryParams = TypedDict(
-    "ListSessionsQueryParams",
-    {
-        "pageSize": NotRequired[int | None],
-        "sessionType": Literal["Online", "Batch"],
-        "referenceNumber": NotRequired[str | None],
-        "dateCreatedFrom": NotRequired[str | None],
-        "dateCreatedTo": NotRequired[str | None],
-        "dateClosedFrom": NotRequired[str | None],
-        "dateClosedTo": NotRequired[str | None],
-        "dateModifiedFrom": NotRequired[str | None],
-        "dateModifiedTo": NotRequired[str | None],
-        "statuses": NotRequired[
-            list[Literal["InProgress", "Succeeded", "Failed", "Cancelled"]] | None
-        ],
-    },
-)
 _LIST_SESSIONS_PARAMS = TypeAdapter(ListSessionsQueryParams)
 
 

--- a/src/ksef2/endpoints/async_tokens.py
+++ b/src/ksef2/endpoints/async_tokens.py
@@ -1,23 +1,14 @@
 """Async token endpoints for managing access tokens."""
 
-from typing import NotRequired, TypedDict, Unpack, final
+from typing import Unpack, final
 
 from pydantic import TypeAdapter
 
 from ksef2.core import routes
+from ksef2.domain.types import ListTokensQueryParams
 from ksef2.endpoints.async_base import AsyncBaseEndpoints
 from ksef2.infra.schema.api import spec
 
-ListTokensQueryParams = TypedDict(
-    "ListTokensQueryParams",
-    {
-        "status": NotRequired[list[str] | None],
-        "description": NotRequired[str | None],
-        "authorIdentifier": NotRequired[str | None],
-        "authorIdentifierType": NotRequired[str | None],
-        "pageSize": NotRequired[int | None],
-    },
-)
 _LIST_TOKENS_PARAMS = TypeAdapter(ListTokensQueryParams)
 
 

--- a/src/ksef2/endpoints/base.py
+++ b/src/ksef2/endpoints/base.py
@@ -2,21 +2,14 @@
 
 import abc
 from collections.abc import Mapping
-from typing import ClassVar, NotRequired, TypedDict
+from typing import ClassVar
 from urllib.parse import urlencode
 
 import httpx
 from pydantic import BaseModel, TypeAdapter, ValidationError
 from ksef2.core import codecs, exceptions
 from ksef2.core.protocols import Middleware
-
-OffsetPaginationQueryParams = TypedDict(
-    "OffsetPaginationQueryParams",
-    {
-        "pageOffset": NotRequired[int | None],
-        "pageSize": NotRequired[int | None],
-    },
-)
+from ksef2.domain.types import OffsetPaginationQueryParams
 
 
 class BaseEndpoints(abc.ABC):

--- a/src/ksef2/endpoints/certificates.py
+++ b/src/ksef2/endpoints/certificates.py
@@ -1,7 +1,7 @@
 from typing import final, Unpack
 
 from ksef2.core import routes
-from ksef2.endpoints.base import OffsetPaginationQueryParams
+from ksef2.domain.types import OffsetPaginationQueryParams
 from ksef2.endpoints.base import BaseEndpoints
 from ksef2.infra.schema.api import spec
 

--- a/src/ksef2/endpoints/invoices.py
+++ b/src/ksef2/endpoints/invoices.py
@@ -1,8 +1,9 @@
-from typing import NotRequired, TypedDict, Unpack, final
+from typing import TypedDict, Unpack, final
 
 from pydantic import TypeAdapter
 
 from ksef2.core import routes
+from ksef2.domain.types import InvoiceMetadataQueryParams
 from ksef2.endpoints.base import BaseEndpoints
 from ksef2.infra.schema.api import spec
 from ksef2.infra.schema.api.supp.invoices import (
@@ -10,14 +11,6 @@ from ksef2.infra.schema.api.supp.invoices import (
     SendInvoiceRequest,
 )
 
-InvoiceMetadataQueryParams = TypedDict(
-    "InvoiceMetadataQueryParams",
-    {
-        "sortOrder": NotRequired[str | None],
-        "pageOffset": NotRequired[int | None],
-        "pageSize": NotRequired[int | None],
-    },
-)
 SessionInvoiceListQueryParams = TypedDict(
     "SessionInvoiceListQueryParams",
     {

--- a/src/ksef2/endpoints/peppol.py
+++ b/src/ksef2/endpoints/peppol.py
@@ -3,7 +3,7 @@
 from typing import final, Unpack
 
 from ksef2.core import routes
-from ksef2.endpoints.base import OffsetPaginationQueryParams
+from ksef2.domain.types import OffsetPaginationQueryParams
 from ksef2.endpoints.base import BaseEndpoints
 from ksef2.infra.schema.api import spec
 

--- a/src/ksef2/endpoints/permissions.py
+++ b/src/ksef2/endpoints/permissions.py
@@ -1,7 +1,7 @@
 from typing import final, Unpack
 
 from ksef2.core import routes
-from ksef2.endpoints.base import OffsetPaginationQueryParams
+from ksef2.domain.types import OffsetPaginationQueryParams
 from ksef2.endpoints.base import BaseEndpoints
 from ksef2.infra.schema.api import spec
 

--- a/src/ksef2/endpoints/session.py
+++ b/src/ksef2/endpoints/session.py
@@ -1,32 +1,16 @@
 """Session management endpoints."""
 
-from typing import Literal, NotRequired, TypedDict, Unpack, final
+from typing import Unpack, final
 
 from pydantic import TypeAdapter
 
 from ksef2.core import routes
+from ksef2.domain.types import ListSessionsQueryParams
 from ksef2.endpoints.base import BaseEndpoints
 from ksef2.infra.schema.api import spec
 from ksef2.infra.schema.api.supp.batch import OpenBatchSessionRequest
 from ksef2.infra.schema.api.supp.session import OpenOnlineSessionRequest
 
-ListSessionsQueryParams = TypedDict(
-    "ListSessionsQueryParams",
-    {
-        "pageSize": NotRequired[int | None],
-        "sessionType": Literal["Online", "Batch"],
-        "referenceNumber": NotRequired[str | None],
-        "dateCreatedFrom": NotRequired[str | None],
-        "dateCreatedTo": NotRequired[str | None],
-        "dateClosedFrom": NotRequired[str | None],
-        "dateClosedTo": NotRequired[str | None],
-        "dateModifiedFrom": NotRequired[str | None],
-        "dateModifiedTo": NotRequired[str | None],
-        "statuses": NotRequired[
-            list[Literal["InProgress", "Succeeded", "Failed", "Cancelled"]] | None
-        ],
-    },
-)
 _LIST_SESSIONS_PARAMS = TypeAdapter(ListSessionsQueryParams)
 
 

--- a/src/ksef2/endpoints/shared.py
+++ b/src/ksef2/endpoints/shared.py
@@ -1,19 +1,12 @@
 from collections.abc import Mapping
-from typing import NotRequired, Protocol, TypedDict, cast
+from typing import Protocol, cast
 from urllib.parse import urlencode
 
 import httpx
 from pydantic import BaseModel, TypeAdapter, ValidationError
 
 from ksef2.core import codecs, exceptions
-
-OffsetPaginationQueryParams = TypedDict(
-    "OffsetPaginationQueryParams",
-    {
-        "pageOffset": NotRequired[int | None],
-        "pageSize": NotRequired[int | None],
-    },
-)
+from ksef2.domain.types import OffsetPaginationQueryParams
 
 
 class QueryParamsAdapter(Protocol):

--- a/src/ksef2/endpoints/tokens.py
+++ b/src/ksef2/endpoints/tokens.py
@@ -1,23 +1,14 @@
 """Token endpoints for managing access tokens."""
 
-from typing import NotRequired, TypedDict, Unpack, final
+from typing import Unpack, final
 
 from pydantic import TypeAdapter
 
 from ksef2.core import routes
+from ksef2.domain.types import ListTokensQueryParams
 from ksef2.endpoints.base import BaseEndpoints
 from ksef2.infra.schema.api import spec
 
-ListTokensQueryParams = TypedDict(
-    "ListTokensQueryParams",
-    {
-        "status": NotRequired[list[str] | None],
-        "description": NotRequired[str | None],
-        "authorIdentifier": NotRequired[str | None],
-        "authorIdentifierType": NotRequired[str | None],
-        "pageSize": NotRequired[int | None],
-    },
-)
 _LIST_TOKENS_PARAMS = TypeAdapter(ListTokensQueryParams)
 
 

--- a/src/ksef2/services/auth.py
+++ b/src/ksef2/services/auth.py
@@ -1,5 +1,0 @@
-from ksef2.clients.auth import AuthClient
-
-AuthService = AuthClient
-
-__all__ = ["AuthService"]

--- a/tests/unit/endpoints/test_tokens_endpoints.py
+++ b/tests/unit/endpoints/test_tokens_endpoints.py
@@ -7,7 +7,8 @@ from pydantic import BaseModel
 
 from ksef2.core import exceptions
 from ksef2.core.routes import TokenRoutes
-from ksef2.endpoints.tokens import TokenEndpoints, ListTokensQueryParams
+from ksef2.domain.types import ListTokensQueryParams
+from ksef2.endpoints.tokens import TokenEndpoints
 from tests.unit.fakes import transport
 from tests.unit.factories.tokens import (
     GenerateTokenRequestFactory,

--- a/tests/unit/factories/pagination.py
+++ b/tests/unit/factories/pagination.py
@@ -1,14 +1,12 @@
 import pytest
 
 from ksef2.domain.models.pagination import (
+    InvoiceMetadataParams,
     OffsetPaginationParams,
     PermissionsQueryParams,
-    TokenPaginationParams,
-    SessionListParams,
     SessionInvoiceListParams,
+    TokenPaginationParams,
     TokenListParams,
-    AuthSessionListParams,
-    InvoiceMetadataParams,
 )
 
 
@@ -38,11 +36,6 @@ def token_pagination_params() -> TokenPaginationParams:
 
 
 @pytest.fixture
-def session_list_params() -> SessionListParams:
-    return SessionListParams(session_type="online")
-
-
-@pytest.fixture
 def session_invoice_list_params() -> SessionInvoiceListParams:
     return SessionInvoiceListParams()
 
@@ -50,8 +43,3 @@ def session_invoice_list_params() -> SessionInvoiceListParams:
 @pytest.fixture
 def token_list_params() -> TokenListParams:
     return TokenListParams()
-
-
-@pytest.fixture
-def auth_session_list_params() -> AuthSessionListParams:
-    return AuthSessionListParams()


### PR DESCRIPTION
Refs #61

## Summary
- Move shared query-parameter TypedDicts from endpoint modules into `ksef2.domain.types` so domain models no longer import endpoint-layer modules.
- Deduplicate `ListSessionsQueryParams` across sync and async session endpoints.
- Remove the unused `AuthService` alias and factory-only pagination helpers.

## Notes
- `src/ksef2/core/invoices.py` was kept because `InvoiceTemplater` is still used by integration tests, example scripts, and docs.

## Verification
- `just sync`
- `just lint && just format-check && just typecheck && just test`