### PR TITLE
Clean public API, packaging, and timeout errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ asyncio.run(main())
 
 See [`docs/guides/async-client.md`](docs/guides/async-client.md) for async usage patterns.
 
+## Error Handling
+
+Catch stable SDK exception classes from the package root, for example
+`KSeFApiError`, `KSeFRateLimitError`, and the polling timeout errors. See
+[`docs/guides/errors.md`](docs/guides/errors.md) for the exception hierarchy,
+KSeF `ExceptionCode` handling, retry patterns, and timeout semantics.
+
 ## Features
 
 - **Typed public API** for authentication, sessions, invoices, tokens, permissions, limits, certificates, and PEPPOL

--- a/docs/guides/errors.md
+++ b/docs/guides/errors.md
@@ -1,0 +1,127 @@
+# Error Handling
+
+The SDK raises `KSeFException` subclasses for errors it can classify. Import
+stable exception classes from the package root:
+
+```python
+from ksef2 import KSeFApiError, KSeFRateLimitError, KSeFTokenStatusTimeoutError
+```
+
+`ksef2.core.exceptions` remains importable for applications that already use
+that path.
+
+## Exception Hierarchy
+
+```text
+KSeFException
+├── KSeFApiError
+│   ├── KSeFAuthError
+│   └── KSeFRateLimitError
+├── KSeFValidationError
+├── KSeFEncryptionError
+├── KSeFSessionError
+├── KSeFClientClosedError
+├── KSeFUnsupportedEnvironmentError
+├── NoCertificateAvailableError
+├── KSeFMetadataPaginationError
+├── KSeFExportTimeoutError
+├── KSeFInvoiceQueryTimeoutError
+├── KSeFInvoiceDownloadTimeoutError
+├── KSeFInvoiceProcessingTimeoutError
+├── KSeFBatchSessionTimeoutError
+├── KSeFAuthPollingTimeoutError
+└── KSeFTokenStatusTimeoutError
+```
+
+## API Errors
+
+`KSeFApiError` represents an error response from KSeF. It exposes:
+
+- `status_code`: the HTTP status code returned by KSeF
+- `exception_code`: an `ExceptionCode` value
+- `response`: the parsed response model when one was available
+
+`KSeFAuthError` is used for authentication and authorization responses such as
+401 and 403. `KSeFRateLimitError` is used for 429 responses and includes
+`retry_after`, populated from the response headers when KSeF provides it.
+
+```python
+from ksef2 import KSeFApiError, KSeFRateLimitError
+
+try:
+    page = auth.tokens.list_page()
+except KSeFRateLimitError as exc:
+    print(f"Retry after {exc.retry_after} seconds")
+except KSeFApiError as exc:
+    print(exc.status_code, exc.exception_code)
+```
+
+## Exception Codes
+
+`ExceptionCode` contains SDK-known KSeF exception codes, including
+`NOT_PROCESSED_YET`. When KSeF returns a code unknown to this SDK version, it is
+mapped to `ExceptionCode.UNKNOWN_ERROR` so callers always receive a valid enum
+value.
+
+For invoice downloads, KSeF can return `NOT_PROCESSED_YET` while the invoice is
+still being prepared. The SDK's invoice service uses that code as a retry signal:
+
+```python
+from ksef2 import ExceptionCode, KSeFApiError
+
+try:
+    xml = auth.invoices.download_invoice(ksef_number="KSeF-number")
+except KSeFApiError as exc:
+    if exc.exception_code is ExceptionCode.NOT_PROCESSED_YET:
+        # Wait and retry, or call wait_for_invoice_download(...).
+        ...
+    else:
+        raise
+```
+
+For that workflow, prefer the built-in helper when possible:
+
+```python
+xml = auth.invoices.wait_for_invoice_download(ksef_number="KSeF-number")
+```
+
+## Polling Timeouts
+
+Timeout exceptions raised by SDK-side polling helpers do not represent HTTP
+responses and do not expose `status_code`.
+
+- `KSeFAuthPollingTimeoutError`: authentication status polling exceeded
+  `max_poll_attempts`
+- `KSeFTokenStatusTimeoutError`: generated token status polling exceeded
+  `max_poll_attempts`
+- `KSeFInvoiceDownloadTimeoutError`: invoice download polling exceeded
+  `timeout`
+- `KSeFInvoiceQueryTimeoutError`: invoice metadata polling exceeded `timeout`
+- `KSeFExportTimeoutError`: export package polling exceeded `timeout`
+- `KSeFInvoiceProcessingTimeoutError`: session invoice processing exceeded
+  `timeout`
+- `KSeFBatchSessionTimeoutError`: batch session processing exceeded `timeout`
+
+The attempt-based timeout errors expose `reference_number`, `attempts`,
+`poll_interval`, and `elapsed`. Time-based timeout errors expose their relevant
+reference fields and `timeout`.
+
+```python
+from ksef2 import KSeFTokenStatusTimeoutError
+
+try:
+    token = auth.tokens.generate(
+        permissions=["invoice_read"],
+        description="Reporting",
+        max_poll_attempts=10,
+    )
+except KSeFTokenStatusTimeoutError as exc:
+    print(exc.reference_number, exc.attempts, exc.elapsed)
+```
+
+## Validation and SDK State Errors
+
+`KSeFValidationError` covers SDK-side validation failures. State and capability
+errors use narrower subclasses such as `KSeFSessionError`,
+`KSeFClientClosedError`, `KSeFUnsupportedEnvironmentError`, and
+`NoCertificateAvailableError`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,10 @@ dependencies = [
     "signxml>=4.0",
     "httpx[http2]>=0.28.1",
     "structlog>=25.5.0",
-    "dotenv>=0.9.9",
-    "requests>=2.32.5",
     "xsdata-pydantic>=24.5",
     "tenacity>=9.0",
-    "polyfactory>=3.3.0",
     "beartype>=0.22.9",
     "camel-converter>=5.1.0",
-    "pytest-cov>=7.1.0",
     "xsdata>=26.1",
 ]
 
@@ -41,6 +37,9 @@ dev = [
     "commitizen>=4.13.9",
     "pre-commit>=4.5.1",
     "pytest-asyncio>=1.3.0",
+    "polyfactory>=3.3.0",
+    "pytest-cov>=7.1.0",
+    "python-dotenv>=1.2.1",
 ]
 codegen = [
     "datamodel-code-generator[ruff]>=0.53.0",

--- a/src/ksef2/__init__.py
+++ b/src/ksef2/__init__.py
@@ -19,6 +19,7 @@ beartype_this_package(
 from ksef2.clients.async_base import AsyncClient
 from ksef2.clients.base import Client
 from ksef2.domain.models import FormSchema
+from ksef2.__version__ import version as __version__
 from ksef2.config import (
     ConnectionPoolConfig,
     Environment,
@@ -27,15 +28,58 @@ from ksef2.config import (
     TlsConfig,
     TransportConfig,
 )
+from ksef2.core.exceptions import (
+    ExceptionCode,
+    KSeFApiError,
+    KSeFAuthError,
+    KSeFAuthPollingTimeoutError,
+    KSeFBatchSessionTimeoutError,
+    KSeFClientClosedError,
+    KSeFEncryptionError,
+    KSeFException,
+    KSeFExportTimeoutError,
+    KSeFInvoiceDownloadTimeoutError,
+    KSeFInvoiceProcessingTimeoutError,
+    KSeFInvoiceQueryTimeoutError,
+    KSeFInvoiceRenderingError,
+    KSeFMetadataPaginationError,
+    KSeFRateLimitError,
+    KSeFSessionError,
+    KSeFTokenStatusTimeoutError,
+    KSeFUnsupportedEnvironmentError,
+    KSeFValidationError,
+    NoCertificateAvailableError,
+)
 
 __all__ = [
     "AsyncClient",
     "Client",
     "ConnectionPoolConfig",
     "Environment",
+    "ExceptionCode",
     "FormSchema",
+    "KSeFApiError",
+    "KSeFAuthError",
+    "KSeFAuthPollingTimeoutError",
+    "KSeFBatchSessionTimeoutError",
+    "KSeFClientClosedError",
+    "KSeFEncryptionError",
+    "KSeFException",
+    "KSeFExportTimeoutError",
+    "KSeFInvoiceDownloadTimeoutError",
+    "KSeFInvoiceProcessingTimeoutError",
+    "KSeFInvoiceQueryTimeoutError",
+    "KSeFInvoiceRenderingError",
+    "KSeFMetadataPaginationError",
+    "KSeFRateLimitError",
+    "KSeFSessionError",
+    "KSeFTokenStatusTimeoutError",
+    "KSeFUnsupportedEnvironmentError",
+    "KSeFValidationError",
+    "NoCertificateAvailableError",
     "RetryConfig",
     "TimeoutConfig",
     "TlsConfig",
     "TransportConfig",
+    "__version__",
 ]

--- a/src/ksef2/clients/async_auth.py
+++ b/src/ksef2/clients/async_auth.py
@@ -9,7 +9,6 @@ from ksef2.config import Environment
 from ksef2.core import exceptions
 from ksef2.core.async_protocols import AsyncMiddleware
 from ksef2.core.crypto import encrypt_token
-from ksef2.core.exceptions import KSeFAuthError
 from ksef2.core.polling import async_poll_until
 from ksef2.core.stores import CertificateStore
 from ksef2.core.xades import XAdESPrivateKey, generate_test_certificate
@@ -192,7 +191,7 @@ class AsyncAuthClient:
                 )
             )
             if status.status_code >= 400:
-                raise KSeFAuthError(
+                raise exceptions.KSeFAuthError(
                     status_code=status.status_code,
                     message=f"Authentication failed: {status.status_description}",
                 )
@@ -203,8 +202,9 @@ class AsyncAuthClient:
             retry_predicate=lambda status: status.status_code < 200,
             poll_interval=poll_interval,
             max_attempts=max_attempts,
-            timeout_error_factory=lambda: KSeFAuthError(
-                status_code=408,
-                message="Authentication polling timed out.",
+            timeout_error_factory=lambda: exceptions.KSeFAuthPollingTimeoutError(
+                reference_number=reference_number_local,
+                attempts=max_attempts,
+                poll_interval=poll_interval,
             ),
         )

--- a/src/ksef2/clients/async_tokens.py
+++ b/src/ksef2/clients/async_tokens.py
@@ -47,10 +47,10 @@ class AsyncTokensClient:
             retry_predicate=lambda result: result.status != "active",
             poll_interval=poll_interval,
             max_attempts=max_attempts,
-            timeout_error_factory=lambda: exceptions.KSeFApiError(
-                0,
-                exceptions.ExceptionCode.UNKNOWN_ERROR,
-                f"Token activation polling timed out after {max_attempts} attempts",
+            timeout_error_factory=lambda: exceptions.KSeFTokenStatusTimeoutError(
+                reference_number=reference_number_local,
+                attempts=max_attempts,
+                poll_interval=poll_interval,
             ),
         )
 

--- a/src/ksef2/clients/auth.py
+++ b/src/ksef2/clients/auth.py
@@ -9,7 +9,6 @@ from ksef2.clients.encryption import EncryptionClient
 from ksef2.config import Environment
 from ksef2.core import exceptions
 from ksef2.core.crypto import encrypt_token
-from ksef2.core.exceptions import KSeFAuthError
 from ksef2.core.protocols import Middleware
 from ksef2.core.stores import CertificateStore
 from ksef2.domain.models.auth import (
@@ -63,7 +62,9 @@ class AuthClient:
         Raises:
             NoCertificateAvailableError: If no valid token-encryption certificate is
                 available.
-            KSeFAuthError: If authentication fails or polling times out.
+            KSeFAuthError: If authentication fails.
+            KSeFAuthPollingTimeoutError: If polling exceeds
+                ``max_poll_attempts``.
         """
         self._ensure_certificates()
 
@@ -205,7 +206,7 @@ class AuthClient:
                 )
             )
             if status.status_code >= 400:
-                raise KSeFAuthError(
+                raise exceptions.KSeFAuthError(
                     status_code=status.status_code,
                     message=f"Authentication failed: {status.status_description}",
                 )
@@ -216,9 +217,10 @@ class AuthClient:
             retry_predicate=lambda status: status.status_code < 200,
             poll_interval=poll_interval,
             max_attempts=max_attempts,
-            timeout_error_factory=lambda: KSeFAuthError(
-                status_code=408,
-                message="Authentication polling timed out.",
+            timeout_error_factory=lambda: exceptions.KSeFAuthPollingTimeoutError(
+                reference_number=reference_number_local,
+                attempts=max_attempts,
+                poll_interval=poll_interval,
             ),
         )
 

--- a/src/ksef2/clients/tokens.py
+++ b/src/ksef2/clients/tokens.py
@@ -49,10 +49,10 @@ class TokensClient:
             retry_predicate=lambda result: result.status != "active",
             poll_interval=poll_interval,
             max_attempts=max_attempts,
-            timeout_error_factory=lambda: exceptions.KSeFApiError(
-                0,
-                exceptions.ExceptionCode.UNKNOWN_ERROR,
-                f"Token activation polling timed out after {max_attempts} attempts",
+            timeout_error_factory=lambda: exceptions.KSeFTokenStatusTimeoutError(
+                reference_number=reference_number_local,
+                attempts=max_attempts,
+                poll_interval=poll_interval,
             ),
         )
 
@@ -78,6 +78,8 @@ class TokensClient:
         Raises:
             KSeFApiError: If activation ends in a terminal failure state or polling
                 exceeds ``max_poll_attempts``.
+            KSeFTokenStatusTimeoutError: If polling exceeds
+                ``max_poll_attempts``.
         """
         request = GenerateTokenRequest(
             permissions=permissions,

--- a/src/ksef2/core/exceptions.py
+++ b/src/ksef2/core/exceptions.py
@@ -170,6 +170,56 @@ class KSeFExportTimeoutError(KSeFException):
         )
 
 
+class KSeFAuthPollingTimeoutError(KSeFException):
+    """Raised when polling for authentication completion exceeds the limit."""
+
+    code: str = "AUTH_POLLING_TIMEOUT"
+
+    def __init__(
+        self,
+        reference_number: str,
+        attempts: int,
+        poll_interval: float,
+    ) -> None:
+        elapsed = attempts * poll_interval
+        self.reference_number = reference_number
+        self.attempts = attempts
+        self.poll_interval = poll_interval
+        self.elapsed = elapsed
+        super().__init__(
+            f"Authentication {reference_number} not ready after {attempts} attempts",
+            reference_number=reference_number,
+            attempts=attempts,
+            poll_interval=poll_interval,
+            elapsed=elapsed,
+        )
+
+
+class KSeFTokenStatusTimeoutError(KSeFException):
+    """Raised when polling for a token status change exceeds the limit."""
+
+    code: str = "TOKEN_STATUS_TIMEOUT"
+
+    def __init__(
+        self,
+        reference_number: str,
+        attempts: int,
+        poll_interval: float,
+    ) -> None:
+        elapsed = attempts * poll_interval
+        self.reference_number = reference_number
+        self.attempts = attempts
+        self.poll_interval = poll_interval
+        self.elapsed = elapsed
+        super().__init__(
+            f"Token {reference_number} not active after {attempts} attempts",
+            reference_number=reference_number,
+            attempts=attempts,
+            poll_interval=poll_interval,
+            elapsed=elapsed,
+        )
+
+
 class KSeFInvoiceQueryTimeoutError(KSeFException):
     """Raised when polling for invoices to appear exceeds the timeout."""
 

--- a/tests/unit/clients/test_async_auth.py
+++ b/tests/unit/clients/test_async_auth.py
@@ -10,6 +10,7 @@ from ksef2.clients.async_authenticated import AsyncAuthenticatedClient
 from ksef2.config import Environment
 from ksef2.core.exceptions import (
     KSeFAuthError,
+    KSeFAuthPollingTimeoutError,
     KSeFUnsupportedEnvironmentError,
     NoCertificateAvailableError,
 )
@@ -171,7 +172,7 @@ class TestAsyncAuthClient:
         async_fake_transport.enqueue(pending_status.model_dump(mode="json"))
         async_fake_transport.enqueue(pending_status.model_dump(mode="json"))
 
-        with pytest.raises(KSeFAuthError, match="timed out"):
+        with pytest.raises(KSeFAuthPollingTimeoutError, match="not ready") as exc_info:
             asyncio.run(
                 client.with_token(
                     ksef_token="ksef-token",
@@ -180,6 +181,10 @@ class TestAsyncAuthClient:
                     max_poll_attempts=2,
                 )
             )
+
+        assert exc_info.value.reference_number == init_response.referenceNumber
+        assert exc_info.value.attempts == 2
+        assert not hasattr(exc_info.value, "status_code")
 
     @patch(
         "ksef2.core.xades.sign_xades",

--- a/tests/unit/clients/test_async_tokens.py
+++ b/tests/unit/clients/test_async_tokens.py
@@ -119,7 +119,10 @@ class TestAsyncTokensClient:
         for _ in range(3):
             async_fake_transport.enqueue(pending_resp.model_dump(mode="json"))
 
-        with pytest.raises(exceptions.KSeFApiError, match="polling timed out"):
+        with pytest.raises(
+            exceptions.KSeFTokenStatusTimeoutError,
+            match="not active",
+        ) as exc_info:
             _ = asyncio.run(
                 tokens_client.generate(
                     permissions=["invoice_read"],
@@ -128,6 +131,10 @@ class TestAsyncTokensClient:
                     max_poll_attempts=3,
                 )
             )
+
+        assert exc_info.value.reference_number == gen_resp.referenceNumber
+        assert exc_info.value.attempts == 3
+        assert not hasattr(exc_info.value, "status_code")
 
     def test_generate_zero_max_poll_attempts_does_not_poll_status(
         self,
@@ -138,7 +145,10 @@ class TestAsyncTokensClient:
         gen_resp = token_generate_resp.build()
         async_fake_transport.enqueue(gen_resp.model_dump(mode="json"))
 
-        with pytest.raises(exceptions.KSeFApiError, match="polling timed out"):
+        with pytest.raises(
+            exceptions.KSeFTokenStatusTimeoutError,
+            match="not active",
+        ) as exc_info:
             _ = asyncio.run(
                 tokens_client.generate(
                     permissions=["invoice_read"],
@@ -147,6 +157,10 @@ class TestAsyncTokensClient:
                     max_poll_attempts=0,
                 )
             )
+
+        assert exc_info.value.reference_number == gen_resp.referenceNumber
+        assert exc_info.value.attempts == 0
+        assert not hasattr(exc_info.value, "status_code")
 
         assert len(async_fake_transport.calls) == 1
         assert async_fake_transport.calls[0].method == "POST"

--- a/tests/unit/clients/test_auth.py
+++ b/tests/unit/clients/test_auth.py
@@ -15,6 +15,7 @@ from ksef2.config import Environment
 from ksef2.core.xades import generate_test_certificate
 from ksef2.core.exceptions import (
     KSeFAuthError,
+    KSeFAuthPollingTimeoutError,
     KSeFUnsupportedEnvironmentError,
     NoCertificateAvailableError,
 )
@@ -191,13 +192,17 @@ class TestAuthClient:
         fake_transport.enqueue(pending_status.model_dump(mode="json"))
         fake_transport.enqueue(pending_status.model_dump(mode="json"))
 
-        with pytest.raises(KSeFAuthError, match="timed out"):
+        with pytest.raises(KSeFAuthPollingTimeoutError, match="not ready") as exc_info:
             _ = client.with_token(
                 ksef_token="ksef-token",
                 nip="1234567890",
                 poll_interval=0.0,
                 max_poll_attempts=2,
             )
+
+        assert exc_info.value.reference_number == init_response.referenceNumber
+        assert exc_info.value.attempts == 2
+        assert not hasattr(exc_info.value, "status_code")
 
     @patch(
         "ksef2.core.xades.sign_xades",

--- a/tests/unit/clients/test_tokens.py
+++ b/tests/unit/clients/test_tokens.py
@@ -102,13 +102,20 @@ class TestTokensClient:
         for _ in range(3):
             fake_transport.enqueue(pending_resp.model_dump(mode="json"))
 
-        with pytest.raises(exceptions.KSeFApiError, match="polling timed out"):
+        with pytest.raises(
+            exceptions.KSeFTokenStatusTimeoutError,
+            match="not active",
+        ) as exc_info:
             _ = tokens_client.generate(
                 permissions=["invoice_read"],
                 description="Test token",
                 poll_interval=0.0,
                 max_poll_attempts=3,
             )
+
+        assert exc_info.value.reference_number == gen_resp.referenceNumber
+        assert exc_info.value.attempts == 3
+        assert not hasattr(exc_info.value, "status_code")
 
     def test_generate_zero_max_poll_attempts_does_not_poll_status(
         self,
@@ -119,13 +126,20 @@ class TestTokensClient:
         gen_resp = token_generate_resp.build()
         fake_transport.enqueue(gen_resp.model_dump(mode="json"))
 
-        with pytest.raises(exceptions.KSeFApiError, match="polling timed out"):
+        with pytest.raises(
+            exceptions.KSeFTokenStatusTimeoutError,
+            match="not active",
+        ) as exc_info:
             _ = tokens_client.generate(
                 permissions=["invoice_read"],
                 description="Test token",
                 poll_interval=0.0,
                 max_poll_attempts=0,
             )
+
+        assert exc_info.value.reference_number == gen_resp.referenceNumber
+        assert exc_info.value.attempts == 0
+        assert not hasattr(exc_info.value, "status_code")
 
         assert len(fake_transport.calls) == 1
         assert fake_transport.calls[0].method == "POST"

--- a/tests/unit/test_imports.py
+++ b/tests/unit/test_imports.py
@@ -15,6 +15,22 @@ def test_public_clients_import() -> None:
     assert AsyncClient.__name__ == "AsyncClient"
 
 
+def test_root_error_surface_import() -> None:
+    import ksef2
+
+    assert ksef2.__version__
+    assert ksef2.KSeFException.__name__ == "KSeFException"
+    assert ksef2.KSeFApiError.__name__ == "KSeFApiError"
+    assert ksef2.KSeFAuthError.__name__ == "KSeFAuthError"
+    assert ksef2.KSeFValidationError.__name__ == "KSeFValidationError"
+    assert ksef2.KSeFRateLimitError.__name__ == "KSeFRateLimitError"
+    assert ksef2.KSeFAuthPollingTimeoutError.__name__ == "KSeFAuthPollingTimeoutError"
+    assert ksef2.KSeFTokenStatusTimeoutError.__name__ == "KSeFTokenStatusTimeoutError"
+    assert ksef2.ExceptionCode.UNKNOWN_ERROR == 10000
+    assert "KSeFApiError" in ksef2.__all__
+    assert "__version__" in ksef2.__all__
+
+
 def test_common_domain_models_import() -> None:
     from ksef2.domain.models import InvoiceMetadataParams, InvoicesFilter
 

--- a/uv.lock
+++ b/uv.lock
@@ -540,17 +540,6 @@ wheels = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.9.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "python-dotenv" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/b7/545d2c10c1fc15e48653c91efde329a790f2eecfbbf2bd16003b5db2bab0/dotenv-0.9.9-py2.py3-none-any.whl", hash = "sha256:29cf74a087b31dafdb5a446b6d7e11cbce8ed2741540e2339c69fbef92c94ce9", size = 1892, upload-time = "2025-02-19T22:15:01.647Z" },
-]
-
-[[package]]
 name = "faker"
 version = "40.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -770,12 +759,8 @@ dependencies = [
     { name = "beartype" },
     { name = "camel-converter" },
     { name = "cryptography" },
-    { name = "dotenv" },
     { name = "httpx", extra = ["http2"] },
-    { name = "polyfactory" },
     { name = "pydantic" },
-    { name = "pytest-cov" },
-    { name = "requests" },
     { name = "signxml" },
     { name = "structlog" },
     { name = "tenacity" },
@@ -798,9 +783,12 @@ dev = [
     { name = "basedpyright" },
     { name = "commitizen" },
     { name = "lxml-stubs" },
+    { name = "polyfactory" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "python-dotenv" },
     { name = "respx" },
     { name = "ruff" },
 ]
@@ -810,12 +798,8 @@ requires-dist = [
     { name = "beartype", specifier = ">=0.22.9" },
     { name = "camel-converter", specifier = ">=5.1.0" },
     { name = "cryptography", specifier = ">=44.0.0" },
-    { name = "dotenv", specifier = ">=0.9.9" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.28.1" },
-    { name = "polyfactory", specifier = ">=3.3.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
-    { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "requests", specifier = ">=2.32.5" },
     { name = "signxml", specifier = ">=4.0" },
     { name = "structlog", specifier = ">=25.5.0" },
     { name = "tenacity", specifier = ">=9.0" },
@@ -835,9 +819,12 @@ dev = [
     { name = "basedpyright", specifier = ">=1.37.4" },
     { name = "commitizen", specifier = ">=4.13.9" },
     { name = "lxml-stubs", specifier = ">=0.5.1" },
+    { name = "polyfactory", specifier = ">=3.3.0" },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "respx", specifier = ">=0.22.0" },
     { name = "ruff", specifier = ">=0.15.0" },
 ]


### PR DESCRIPTION
## Summary

- remove unused runtime dependencies and move test-only packages into dev dependencies
- add dedicated SDK polling timeout exceptions for auth and token status flows
- export the stable error surface and __version__ from the package root
- add an error handling guide and README link

Closes #64.

## Verification

- just sync
- uv run pytest tests/unit/clients/test_auth.py tests/unit/clients/test_async_auth.py tests/unit/clients/test_tokens.py tests/unit/clients/test_async_tokens.py tests/unit/test_imports.py
- just lint && just format-check && just typecheck && just test
- uv run python -c "import ksef2; print(ksef2.__version__); ksef2.KSeFApiError"
- env UV_PROJECT_ENVIRONMENT=<temp> uv sync --no-dev
- uv pip show --python <temp>/.venv/bin/python requests (not found)