### PR TITLE
Improve async session ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ async def main() -> None:
     async with AsyncClient(Environment.TEST) as client:
         auth = await client.authentication.with_test_certificate(nip=NIP)
 
-        async with await auth.online_session(form_code=FormSchema.FA3) as session:
+        async with auth.online_session(form_code=FormSchema.FA3) as session:
             result = await session.send_invoice(
                 invoice_xml=Path("invoice.xml").read_bytes()
             )
@@ -170,7 +170,7 @@ See [`docs/guides/async-client.md`](docs/guides/async-client.md) for async usage
 Async methods are awaited, and async session/testdata helpers are used with
 `async with`. For example, `client.authentication.with_token(...)` becomes
 `await client.authentication.with_token(...)`, and
-`auth.online_session(...)` becomes `async with await auth.online_session(...)`.
+`auth.online_session(...)` becomes `async with auth.online_session(...)`.
 
 ## Logging
 

--- a/docs/guides/async-client.md
+++ b/docs/guides/async-client.md
@@ -88,7 +88,7 @@ from pathlib import Path
 from ksef2 import FormSchema
 
 
-async with await auth.online_session(form_code=FormSchema.FA3) as session:
+async with auth.online_session(form_code=FormSchema.FA3) as session:
     result = await session.send_invoice(invoice_xml=Path("invoice.xml").read_bytes())
     status = await session.wait_for_invoice_ready(
         invoice_reference_number=result.reference_number,
@@ -180,7 +180,7 @@ print(state.reference_number)
 For explicit upload control:
 
 ```python
-async with await auth.batch.open_session(prepared_batch=prepared) as session:
+async with auth.batch.open_session(prepared_batch=prepared) as session:
     await session.upload_parts()
     status = await session.get_status()
     print(status.status.description)

--- a/docs/guides/invoices.md
+++ b/docs/guides/invoices.md
@@ -3,7 +3,7 @@
 Use online sessions to send invoices and `auth.invoices` for metadata queries, exports, and downloads.
 
 Async applications use the same entry points on `AsyncClient`; await network
-operations and use `async with await auth.online_session(...)` for session
+operations and use `async with auth.online_session(...)` for session
 lifecycle management.
 
 ## Send an Invoice
@@ -45,7 +45,7 @@ from pathlib import Path
 from ksef2 import FormSchema
 
 
-async with await auth.online_session(form_code=FormSchema.FA3) as session:
+async with auth.online_session(form_code=FormSchema.FA3) as session:
     result = await session.send_invoice(invoice_xml=Path("invoice.xml").read_bytes())
     status = await session.wait_for_invoice_ready(
         invoice_reference_number=result.reference_number,

--- a/src/ksef2/clients/_async_session.py
+++ b/src/ksef2/clients/_async_session.py
@@ -1,0 +1,42 @@
+from collections.abc import Coroutine, Generator
+from types import TracebackType
+from typing import Any, Generic, Protocol, Self, TypeVar, runtime_checkable
+
+
+@runtime_checkable
+class _AsyncSessionClient(Protocol):
+    async def __aenter__(self) -> Self: ...
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None: ...
+
+
+_TSession = TypeVar("_TSession", bound=_AsyncSessionClient)
+
+
+class _AwaitableSession(Generic[_TSession]):
+    def __init__(self, coro: Coroutine[Any, Any, _TSession]) -> None:
+        self._coro = coro
+        self._session: _TSession | None = None
+
+    def __await__(self) -> Generator[Any, None, _TSession]:
+        return self._coro.__await__()
+
+    async def __aenter__(self) -> _TSession:
+        session = await self._coro
+        self._session = session
+        return await session.__aenter__()
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        if self._session is None:
+            return
+        await self._session.__aexit__(exc_type, exc_val, exc_tb)

--- a/src/ksef2/clients/async_authenticated.py
+++ b/src/ksef2/clients/async_authenticated.py
@@ -1,6 +1,7 @@
 from functools import cached_property
 from typing import final
 
+from ksef2.clients._async_session import _AwaitableSession
 from ksef2.clients.async_batch import AsyncBatchSessionClient
 from ksef2.clients.async_certificates import AsyncCertificatesClient
 from ksef2.clients.async_encryption import AsyncEncryptionClient
@@ -90,7 +91,14 @@ class AsyncAuthenticatedClient:
         ) = await self._get_encryption_material()
         return aes_key, iv, encrypted_key
 
-    async def online_session(
+    def online_session(
+        self,
+        *,
+        form_code: FormSchema,
+    ) -> _AwaitableSession[AsyncOnlineSessionClient]:
+        return _AwaitableSession(self._open_online_session(form_code=form_code))
+
+    async def _open_online_session(
         self,
         *,
         form_code: FormSchema,
@@ -128,7 +136,24 @@ class AsyncAuthenticatedClient:
     ) -> AsyncOnlineSessionClient:
         return AsyncOnlineSessionClient(transport=self._authed_transport, state=state)
 
-    async def batch_session(
+    def batch_session(
+        self,
+        *,
+        prepared_batch: PreparedBatch | None = None,
+        batch_file: BatchFileInfo | None = None,
+        form_code: FormSchema = FormSchema.FA3,
+        offline_mode: bool = False,
+    ) -> _AwaitableSession[AsyncBatchSessionClient]:
+        return _AwaitableSession(
+            self._open_batch_session_from_input(
+                prepared_batch=prepared_batch,
+                batch_file=batch_file,
+                form_code=form_code,
+                offline_mode=offline_mode,
+            )
+        )
+
+    async def _open_batch_session_from_input(
         self,
         *,
         prepared_batch: PreparedBatch | None = None,
@@ -143,7 +168,7 @@ class AsyncAuthenticatedClient:
 
         if prepared_batch is not None:
             encryption = prepared_batch.encryption
-            return await self.open_batch_session(
+            return await self._open_batch_session(
                 batch_file=prepared_batch.batch_file,
                 aes_key=encryption.get_aes_key_bytes(),
                 iv=encryption.get_iv_bytes(),
@@ -165,7 +190,7 @@ class AsyncAuthenticatedClient:
             encrypted_key,
             public_key_id,
         ) = await self._get_encryption_material()
-        return await self.open_batch_session(
+        return await self._open_batch_session(
             batch_file=batch_file,
             aes_key=aes_key,
             iv=iv,
@@ -175,7 +200,32 @@ class AsyncAuthenticatedClient:
             offline_mode=offline_mode,
         )
 
-    async def open_batch_session(
+    def open_batch_session(
+        self,
+        *,
+        batch_file: BatchFileInfo,
+        aes_key: bytes,
+        iv: bytes,
+        encrypted_key: bytes,
+        public_key_id: str | None = None,
+        form_code: FormSchema = FormSchema.FA3,
+        offline_mode: bool = False,
+        prepared_batch: PreparedBatch | None = None,
+    ) -> _AwaitableSession[AsyncBatchSessionClient]:
+        return _AwaitableSession(
+            self._open_batch_session(
+                batch_file=batch_file,
+                aes_key=aes_key,
+                iv=iv,
+                encrypted_key=encrypted_key,
+                public_key_id=public_key_id,
+                form_code=form_code,
+                offline_mode=offline_mode,
+                prepared_batch=prepared_batch,
+            )
+        )
+
+    async def _open_batch_session(
         self,
         *,
         batch_file: BatchFileInfo,

--- a/src/ksef2/services/async_batch.py
+++ b/src/ksef2/services/async_batch.py
@@ -3,6 +3,7 @@ from collections.abc import Awaitable, Callable, Iterable
 from pathlib import Path
 from typing import final
 
+from ksef2.clients._async_session import _AwaitableSession
 from ksef2.clients.async_batch import AsyncBatchSessionClient
 from ksef2.core import exceptions
 from ksef2.core.async_protocols import AsyncMiddleware
@@ -80,7 +81,14 @@ class AsyncBatchService:
             max_part_size=max_part_size,
         )
 
-    async def open_session(
+    def open_session(
+        self,
+        *,
+        prepared_batch: PreparedBatch,
+    ) -> _AwaitableSession[AsyncBatchSessionClient]:
+        return _AwaitableSession(self._open_session(prepared_batch=prepared_batch))
+
+    async def _open_session(
         self,
         *,
         prepared_batch: PreparedBatch,
@@ -137,7 +145,7 @@ class AsyncBatchService:
         *,
         prepared_batch: PreparedBatch,
     ) -> BatchSessionState:
-        async with await self.open_session(prepared_batch=prepared_batch) as session:
+        async with self.open_session(prepared_batch=prepared_batch) as session:
             state = session.get_state()
             await session.upload_parts()
         return state

--- a/tests/unit/clients/test_async_batch.py
+++ b/tests/unit/clients/test_async_batch.py
@@ -3,10 +3,13 @@ import asyncio
 import pytest
 from polyfactory import BaseFactory
 
+from ksef2.clients.async_authenticated import AsyncAuthenticatedClient
 from ksef2.clients.async_batch import AsyncBatchSessionClient
 from ksef2.core.crypto import sha256_b64
 from ksef2.core.exceptions import KSeFClientClosedError
 from ksef2.core.routes import InvoiceRoutes, SessionRoutes
+from ksef2.core.stores import CertificateStore
+from ksef2.domain.models.auth import AuthTokens
 from ksef2.domain.models.batch import (
     BatchEncryptionData,
     BatchFileInfo,
@@ -15,8 +18,52 @@ from ksef2.domain.models.batch import (
     BatchSessionState,
     PreparedBatch,
 )
+from ksef2.domain.models.session import FormSchema
 from ksef2.infra.schema.api import spec
 from tests.unit.fakes.transport import AsyncFakeTransport
+
+
+def _build_authenticated_client(
+    async_fake_transport: AsyncFakeTransport,
+    auth_tokens: AuthTokens,
+) -> AsyncAuthenticatedClient:
+    return AsyncAuthenticatedClient(
+        transport=async_fake_transport,
+        auth_tokens=auth_tokens,
+        certificate_store=CertificateStore(),
+    )
+
+
+def _build_prepared_batch() -> PreparedBatch:
+    return PreparedBatch(
+        form_code=FormSchema.FA3,
+        offline_mode=False,
+        batch_file=BatchFileInfo(
+            file_size=10,
+            file_hash=sha256_b64(b"plaintext"),
+            parts=[
+                BatchFilePart(
+                    ordinal_number=1,
+                    file_size=12,
+                    file_hash=sha256_b64(b"encrypted"),
+                )
+            ],
+        ),
+        parts=[
+            BatchPreparedPart(
+                ordinal_number=1,
+                content=b"encrypted",
+                file_size=len(b"encrypted"),
+                file_hash=sha256_b64(b"encrypted"),
+            )
+        ],
+        encryption=BatchEncryptionData.from_bytes(
+            aes_key=b"k" * 32,
+            iv=b"v" * 16,
+            encrypted_key=b"enc-key",
+        ),
+        invoices=[],
+    )
 
 
 class TestAsyncBatchSessionClient:
@@ -154,4 +201,84 @@ class TestAsyncBatchSessionClient:
         ].path == SessionRoutes.GET_SESSION_UPO.format(
             referenceNumber=state.reference_number,
             upoReferenceNumber="upo-ref",
+        )
+
+
+class TestAsyncAuthenticatedBatchSession:
+    def test_batch_session_await_returns_client(
+        self,
+        async_fake_transport: AsyncFakeTransport,
+        domain_auth_tokens: BaseFactory[AuthTokens],
+        session_open_batch_resp: BaseFactory[spec.OpenBatchSessionResponse],
+    ) -> None:
+        async_fake_transport.enqueue(
+            session_open_batch_resp.build().model_dump(mode="json")
+        )
+        client = _build_authenticated_client(
+            async_fake_transport,
+            domain_auth_tokens.build(),
+        )
+
+        async def _run() -> AsyncBatchSessionClient:
+            return await client.batch_session(prepared_batch=_build_prepared_batch())
+
+        batch_client = asyncio.run(_run())
+
+        assert isinstance(batch_client, AsyncBatchSessionClient)
+        assert async_fake_transport.calls[0].method == "POST"
+        assert async_fake_transport.calls[0].path == SessionRoutes.OPEN_BATCH
+
+    def test_batch_session_context_manager_opens_and_closes_session(
+        self,
+        async_fake_transport: AsyncFakeTransport,
+        domain_auth_tokens: BaseFactory[AuthTokens],
+        session_open_batch_resp: BaseFactory[spec.OpenBatchSessionResponse],
+    ) -> None:
+        open_response = session_open_batch_resp.build()
+        reference_number = open_response.referenceNumber
+        async_fake_transport.enqueue(open_response.model_dump(mode="json"))
+        async_fake_transport.enqueue({})
+        client = _build_authenticated_client(
+            async_fake_transport,
+            domain_auth_tokens.build(),
+        )
+
+        async def _run() -> None:
+            async with client.batch_session(
+                prepared_batch=_build_prepared_batch()
+            ) as session:
+                assert session.reference_number == reference_number
+
+        asyncio.run(_run())
+
+        assert [call.method for call in async_fake_transport.calls] == ["POST", "POST"]
+        assert async_fake_transport.calls[0].path == SessionRoutes.OPEN_BATCH
+        assert async_fake_transport.calls[1].path == SessionRoutes.CLOSE_BATCH.format(
+            referenceNumber=reference_number
+        )
+
+    def test_batch_session_context_manager_closes_after_exception(
+        self,
+        async_fake_transport: AsyncFakeTransport,
+        domain_auth_tokens: BaseFactory[AuthTokens],
+        session_open_batch_resp: BaseFactory[spec.OpenBatchSessionResponse],
+    ) -> None:
+        open_response = session_open_batch_resp.build()
+        reference_number = open_response.referenceNumber
+        async_fake_transport.enqueue(open_response.model_dump(mode="json"))
+        async_fake_transport.enqueue({})
+        client = _build_authenticated_client(
+            async_fake_transport,
+            domain_auth_tokens.build(),
+        )
+
+        async def _run() -> None:
+            async with client.batch_session(prepared_batch=_build_prepared_batch()):
+                raise ValueError("block failed")
+
+        with pytest.raises(ValueError, match="block failed"):
+            asyncio.run(_run())
+
+        assert async_fake_transport.calls[1].path == SessionRoutes.CLOSE_BATCH.format(
+            referenceNumber=reference_number
         )

--- a/tests/unit/clients/test_async_online.py
+++ b/tests/unit/clients/test_async_online.py
@@ -257,7 +257,10 @@ class TestAsyncAuthenticatedOnlineSession:
             certificate_store=store,
         )
 
-        session_client = asyncio.run(client.online_session(form_code=FormSchema.FA3))
+        async def _run() -> AsyncOnlineSessionClient:
+            return await client.online_session(form_code=FormSchema.FA3)
+
+        session_client = asyncio.run(_run())
 
         assert isinstance(session_client, AsyncOnlineSessionClient)
         call = async_fake_transport.calls[0]
@@ -267,3 +270,99 @@ class TestAsyncAuthenticatedOnlineSession:
         assert call.json is not None
         assert call.json["encryption"]["publicKeyId"] == store.all()[0].public_key_id
         assert session_client.get_state().access_token == "fake-access-token"
+
+    @patch(
+        "ksef2.clients.async_authenticated.encrypt_symmetric_key",
+        return_value=b"enc-key",
+    )
+    @patch(
+        "ksef2.clients.async_authenticated.generate_session_key",
+        return_value=(b"k" * 32, b"v" * 16),
+    )
+    def test_online_session_context_manager_opens_and_closes_session(
+        self,
+        _mock_generate_session_key,
+        _mock_encrypt_symmetric_key,
+        async_fake_transport: AsyncFakeTransport,
+        domain_auth_tokens: BaseFactory[AuthTokens],
+        domain_public_key_cert: BaseFactory[PublicKeyCertificate],
+        session_open_online_resp: BaseFactory[spec.OpenOnlineSessionResponse],
+    ) -> None:
+        reference_number = "20250625-EE-319D7EE000-B67F415CDC-2C"
+        open_response = session_open_online_resp.build(referenceNumber=reference_number)
+        async_fake_transport.enqueue(open_response.model_dump(mode="json"))
+        async_fake_transport.enqueue({})
+        store = CertificateStore()
+        store.load(
+            [
+                domain_public_key_cert.build(
+                    usage=["symmetric_key_encryption"],
+                )
+            ]
+        )
+        client = _build_authenticated_client(
+            async_fake_transport,
+            domain_auth_tokens.build(),
+            certificate_store=store,
+        )
+
+        async def _run() -> None:
+            async with client.online_session(form_code=FormSchema.FA3) as session:
+                assert session.get_state().reference_number == reference_number
+
+        asyncio.run(_run())
+
+        assert [call.method for call in async_fake_transport.calls] == ["POST", "POST"]
+        assert async_fake_transport.calls[0].path == SessionRoutes.OPEN_ONLINE
+        assert async_fake_transport.calls[1].path == (
+            SessionRoutes.TERMINATE_ONLINE.format(referenceNumber=reference_number)
+        )
+
+    @patch(
+        "ksef2.clients.async_authenticated.encrypt_symmetric_key",
+        return_value=b"enc-key",
+    )
+    @patch(
+        "ksef2.clients.async_authenticated.generate_session_key",
+        return_value=(b"k" * 32, b"v" * 16),
+    )
+    def test_online_session_context_manager_closes_after_exception(
+        self,
+        _mock_generate_session_key,
+        _mock_encrypt_symmetric_key,
+        async_fake_transport: AsyncFakeTransport,
+        domain_auth_tokens: BaseFactory[AuthTokens],
+        domain_public_key_cert: BaseFactory[PublicKeyCertificate],
+        session_open_online_resp: BaseFactory[spec.OpenOnlineSessionResponse],
+    ) -> None:
+        reference_number = "20250625-EE-319D7EE000-B67F415CDC-2C"
+        async_fake_transport.enqueue(
+            session_open_online_resp.build(referenceNumber=reference_number).model_dump(
+                mode="json"
+            )
+        )
+        async_fake_transport.enqueue({})
+        store = CertificateStore()
+        store.load(
+            [
+                domain_public_key_cert.build(
+                    usage=["symmetric_key_encryption"],
+                )
+            ]
+        )
+        client = _build_authenticated_client(
+            async_fake_transport,
+            domain_auth_tokens.build(),
+            certificate_store=store,
+        )
+
+        async def _run() -> None:
+            async with client.online_session(form_code=FormSchema.FA3):
+                raise ValueError("block failed")
+
+        with pytest.raises(ValueError, match="block failed"):
+            asyncio.run(_run())
+
+        assert async_fake_transport.calls[1].path == (
+            SessionRoutes.TERMINATE_ONLINE.format(referenceNumber=reference_number)
+        )

--- a/tests/unit/services/test_async_batch.py
+++ b/tests/unit/services/test_async_batch.py
@@ -235,6 +235,61 @@ class TestAsyncBatchService:
         assert async_fake_transport.calls[0].method == "PUT"
         assert async_fake_transport.calls[1].method == "POST"
 
+    def test_open_session_context_manager_opens_and_closes_session(
+        self,
+        async_fake_transport: AsyncFakeTransport,
+        domain_batch_session_state: BaseFactory[BatchSessionState],
+    ) -> None:
+        state = domain_batch_session_state.build(reference_number="batch-ref")
+
+        async def _open_batch_session(**kwargs):
+            return AsyncBatchSessionClient(
+                async_fake_transport,
+                state,
+                prepared_batch=kwargs.get("prepared_batch"),
+            )
+
+        service = _build_service(
+            async_fake_transport,
+            open_batch_session=_open_batch_session,
+        )
+        prepared_batch = PreparedBatch(
+            batch_file=BatchFileInfo(
+                file_size=10,
+                file_hash=sha256_b64(b"plaintext"),
+                parts=[
+                    BatchFilePart(
+                        ordinal_number=1,
+                        file_size=12,
+                        file_hash=sha256_b64(b"encrypted"),
+                    )
+                ],
+            ),
+            parts=[
+                BatchPreparedPart(
+                    ordinal_number=1,
+                    content=b"encrypted",
+                    file_size=len(b"encrypted"),
+                    file_hash=sha256_b64(b"encrypted"),
+                )
+            ],
+            encryption=BatchEncryptionData.from_bytes(
+                aes_key=b"k" * 32,
+                iv=b"v" * 16,
+                encrypted_key=b"enc-key",
+            ),
+            invoices=[],
+        )
+        async_fake_transport.enqueue(json_body={})
+
+        async def _run() -> None:
+            async with service.open_session(prepared_batch=prepared_batch) as session:
+                assert session.reference_number == "batch-ref"
+
+        asyncio.run(_run())
+
+        assert async_fake_transport.calls[0].method == "POST"
+
     def test_wait_for_completion_returns_terminal_success(
         self,
         async_fake_transport: AsyncFakeTransport,


### PR DESCRIPTION
## Summary
- Add a typed awaitable async-context wrapper for async session factories.
- Convert async online and batch session factories, including async batch service open_session, so direct async context usage works while await usage remains supported.
- Update quickstarts and guides to drop the async-with-await pattern.

## Validation
- just sync
- just lint && just format-check && just typecheck && just test

Refs #63
