### PR TITLE
docs: document 1.0 release sign-off

### DIFF
--- a/docs/en/reference/release-notes-1-0-0.mdx
+++ b/docs/en/reference/release-notes-1-0-0.mdx
@@ -88,6 +88,25 @@ Pre-1.0 releases shaped the SDK around a stable application surface:
 - moved public documentation into `getting-started`, `concepts`,
   `how-to-guides`, and `reference`.
 
+## Release sign-off
+
+Stable releases are signed off against one exact trusted commit. Before creating
+a release tag, a maintainer can run the **Integration Tests** workflow manually
+from GitHub Actions and select that commit or branch. The workflow runs only for
+trusted repository events, not pull requests or forks, so KSeF TEST credentials
+are never exposed to untrusted code.
+
+Creating an annotated tag such as `v1.0.0` starts **Publish to PyPI** for the
+tagged commit. Its `integration` job runs the credentialed KSeF TEST suite and
+writes the tag, commit SHA, and `TEST` environment to the GitHub Actions job
+summary. Inspect that sign-off before treating the release as successful.
+
+The `publish` job cannot start until that integration job succeeds. It then
+runs the release checks, verifies that the tag, source version, changelog, and
+built artifacts agree, installs the wheel in a clean environment, and smoke
+tests stable imports before publishing. A failed integration or verification
+step prevents the PyPI upload.
+
 ## Upgrade summary
 
 Move application imports to the documented public paths, retest authentication

--- a/docs/pl/reference/release-notes-1-0-0.mdx
+++ b/docs/pl/reference/release-notes-1-0-0.mdx
@@ -91,6 +91,26 @@ Wydania pre-1.0 ukształtowały SDK wokół stabilnej powierzchni aplikacyjnej:
 - dokumentacja publiczna została podzielona na `getting-started`, `concepts`,
   `how-to-guides` i `reference`.
 
+## Zatwierdzenie wydania
+
+Stabilne wydania są zatwierdzane względem jednego, dokładnego commita zaufanego
+repozytorium. Przed utworzeniem tagu wydania maintainer może ręcznie uruchomić
+workflow **Integration Tests** w GitHub Actions i wybrać ten commit albo branch.
+Workflow działa tylko dla zaufanych zdarzeń repozytorium, a nie dla pull requestów
+ani forków, więc dane TEST KSeF nie są udostępniane niezaufanemu kodowi.
+
+Utworzenie adnotowanego tagu, na przykład `v1.0.0`, uruchamia **Publish to
+PyPI** dla otagowanego commita. Job `integration` uruchamia uwierzytelniony
+zestaw testów KSeF TEST i zapisuje tag, SHA commita oraz środowisko `TEST` w
+podsumowaniu joba GitHub Actions. Przed uznaniem wydania za udane sprawdź ten
+zapis zatwierdzenia.
+
+Job `publish` nie może rozpocząć się, dopóki job integracyjny nie zakończy się
+sukcesem. Następnie uruchamia kontrole wydania, weryfikuje zgodność tagu,
+wersji źródłowej, changeloga i zbudowanych artefaktów, instaluje wheel w czystym
+środowisku oraz testuje stabilne importy przed publikacją. Nieudana integracja
+albo weryfikacja blokuje upload do PyPI.
+
 ## Skrót migracji
 
 Przenieś importy aplikacji na udokumentowane ścieżki publiczne, przetestuj


### PR DESCRIPTION
## Summary

Documents the 1.0 release-signoff procedure in English and Polish.

- explains how maintainers run a trusted manual KSeF TEST check for an exact ref;
- explains the tag-triggered integration sign-off and its recorded SHA/environment;
- documents that the publish job cannot run before that integration succeeds;
- records the artifact/version/clean-wheel checks that run before PyPI upload.

## Why

Completes the maintainer-facing release-documentation acceptance criterion from #94.

Closes #94

## Validation

- `python scripts/validate_docs_frontmatter.py docs/`
- `git diff --check`
